### PR TITLE
feat: Add Riwayah listing endpoint (feature/riwayahs_list)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
         args: [--line-length=100]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/apps/content/views/resources.py
+++ b/apps/content/views/resources.py
@@ -5,7 +5,7 @@ from ninja import FilterSchema, Query, Schema
 from ninja.pagination import paginate
 from pydantic import AwareDatetime, Field
 
-from apps.content.models import Resource, UsageEvent, Riwayah, Asset
+from apps.content.models import Asset, Resource, Riwayah, UsageEvent
 from apps.content.tasks import create_usage_event_task
 from apps.core.ninja_utils.ordering_base import ordering
 from apps.core.ninja_utils.request import Request
@@ -82,6 +82,7 @@ class DetailResourceOut(Schema):
     created_at: AwareDatetime
     updated_at: AwareDatetime
 
+
 class ContentRiwayahOut(Schema):
     id: int
     slug: str
@@ -91,6 +92,7 @@ class ContentRiwayahOut(Schema):
         0,
         description="Number of READY recitation assets for this riwayah",
     )
+
 
 @router.get("resources/", response=list[ListResourceOut])
 @paginate
@@ -163,9 +165,6 @@ def detail_resource(request: Request, id: int):
         )
 
     return resource
-
-
-
 
 
 @router.get("riwayahs", response=list[ContentRiwayahOut], auth=None)


### PR DESCRIPTION
Add a new GET endpoint to list Riwayahs that have at least one READY recitation Asset.

This endpoint will return a list of Riwayahs, including their ID, slug, name, Arabic name, and the count of associated READY recitation assets.

The filtering logic ensures that only active Riwayahs with relevant and ready recitation assets are included. The count is annotated specifically for these READY recitation assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint to list riwayahs with recitation metadata.
  * Endpoint returns only active riwayahs that have at least one ready recitation.
  * Each riwayah includes a count of associated recitations.
  * Supports pagination and sorting (by name, name_ar, slug) for easier browsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->