### PR TITLE
feat: Add reciters listing endpoint (develop)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
         args: [--line-length=100]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/apps/content/views/resources.py
+++ b/apps/content/views/resources.py
@@ -1,11 +1,11 @@
-from django.db.models import Q, Count
+from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from ninja import FilterSchema, Query, Schema
 from ninja.pagination import paginate
 from pydantic import AwareDatetime, Field
 
-from apps.content.models import Resource, UsageEvent, Asset, Reciter
+from apps.content.models import Asset, Reciter, Resource, UsageEvent
 from apps.content.tasks import create_usage_event_task
 from apps.core.ninja_utils.ordering_base import ordering
 from apps.core.ninja_utils.request import Request
@@ -82,6 +82,7 @@ class DetailResourceOut(Schema):
     created_at: AwareDatetime
     updated_at: AwareDatetime
 
+
 class ContentReciterOut(Schema):
     id: int
     slug: str
@@ -91,6 +92,7 @@ class ContentReciterOut(Schema):
         0,
         description="Number of READY recitation assets for this reciter",
     )
+
 
 @router.get("resources/", response=list[ListResourceOut])
 @paginate
@@ -163,9 +165,6 @@ def detail_resource(request: Request, id: int):
         )
 
     return resource
-
-
-
 
 
 @router.get("reciters", response=list[ContentReciterOut], auth=None)


### PR DESCRIPTION
Add a new GET endpoint to list reciters that have at least one READY recitation Asset.

This endpoint will return a list of reciters, including their ID, slug, name, Arabic name, and the count of associated READY recitation assets.

The filtering logic ensures that only active reciters with relevant and ready recitation assets are included. The count is annotated specifically for these READY recitation assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint returning reciter records with an exposed recitations_count; supports pagination and sorting by name, alternative name, and slug. Only reciters with available recitations are returned.
* **Chores**
  * Updated development tooling configuration to use a generic Python interpreter version for code formatting hooks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->