### PR TITLE
Return absolute URLs for image and file fields in API responses

### DIFF
--- a/apps/content/tests/test_assets_download.py
+++ b/apps/content/tests/test_assets_download.py
@@ -123,6 +123,7 @@ class TestAssetDownload(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code)
         self.assertIn("download_url", body)
+        self.assertTrue(body["download_url"].startswith("https"))
         self.assertIn("/test.pdf", body["download_url"])
 
     @patch("apps.content.views.assets_download.user_has_access")
@@ -144,6 +145,7 @@ class TestAssetDownload(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code)
         self.assertIn("download_url", body)
+        self.assertTrue(body["download_url"].startswith("https"))
         self.assertIn("/test.csv", body["download_url"])
 
     @patch("apps.content.views.assets_download.user_has_access")
@@ -174,6 +176,7 @@ class TestAssetDownload(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code)
         self.assertIn("download_url", body)
+        self.assertTrue(body["download_url"].startswith("https"))
         self.assertIn("/new.pdf", body["download_url"])
 
     def test_download_asset_with_invalid_id_format_should_return_400(self):

--- a/apps/content/tests/test_detail_assets.py
+++ b/apps/content/tests/test_detail_assets.py
@@ -35,7 +35,8 @@ class DetailAssetTest(BaseTestCase):
         self.assertIn("id", body["publisher"])  # Publisher structure
         self.assertIn("name", body["publisher"])  # Publisher structure
         self.assertIn("description", body["publisher"])  # Publisher structure
-        self.assertTrue(body["thumbnail_url"].endswith("thumbnails/tafseer.png"))
+        self.assertTrue(body["thumbnail_url"].startswith("https"))
+        self.assertIn("thumbnails/tafseer.png", body["thumbnail_url"])
         self.assertEqual("CC-BY-SA", body["license"])
 
     def test_detail_assets_where_response_schema_should_include_all_required_fields(
@@ -117,7 +118,8 @@ class DetailAssetTest(BaseTestCase):
                 self.assertEqual(200, response.status_code, response.content)
                 body = response.json()
                 self.assertEqual(expected_category, body["category"])
-                self.assertTrue(body["thumbnail_url"].endswith(expected_thumb))
+                self.assertTrue(body["thumbnail_url"].startswith("https"))
+                self.assertIn(expected_thumb, body["thumbnail_url"])
 
     def test_detail_assets_where_language_ar_should_return_arabic_content_if_present(
         self,
@@ -143,7 +145,8 @@ class DetailAssetTest(BaseTestCase):
         self.assertEqual("وصف عربي", body["description"])  # Arabic content preserved
         self.assertEqual("وصف عربي مطول", body["long_description"])  # Arabic content preserved
         self.assertEqual("CC0", body["license"])  # CC0 license code
-        self.assertTrue(body["thumbnail_url"].endswith("thumbs/localized.png"))
+        self.assertTrue(body["thumbnail_url"].startswith("https"))
+        self.assertIn("thumbs/localized.png", body["thumbnail_url"])
 
     def test_detail_assets_where_language_ar_missing_translations_should_fallback(self):
         # Arrange
@@ -167,7 +170,7 @@ class DetailAssetTest(BaseTestCase):
         self.assertEqual("English description", body["description"])  # fallback
         self.assertEqual("English long description", body["long_description"])  # fallback
         self.assertEqual("CC0", body["license"])  # CC0 license code
-        self.assertTrue(body["thumbnail_url"].endswith("thumbs/en-only.png"))
+        self.assertIn("thumbs/en-only.png", body["thumbnail_url"])
 
     def test_detail_assets_where_id_format_invalid_should_return_400(self):
         # Arrange - Invalid integer formats should return 400 validation error
@@ -326,7 +329,7 @@ class DetailAssetTest(BaseTestCase):
         body = response.json()
         self.assertEqual(asset.id, body["id"])
         self.assertEqual("Asset Without Thumbnail", body["name"])
-        self.assertIsNone(body["thumbnail_url"])  # Should be null/None
+        self.assertEqual(body["thumbnail_url"], "")
         self.assertEqual("CC0", body["license"])
 
         # Verify other required fields are still present

--- a/apps/content/tests/test_resources_download.py
+++ b/apps/content/tests/test_resources_download.py
@@ -43,6 +43,7 @@ class DownloadResourceTest(BaseTestCase):
             # Assert
             self.assertEqual(200, response.status_code)
             self.assertIn("download_url", body)
+            self.assertTrue(body["download_url"].startswith("https"))
             self.assertIn("/data.csv", body["download_url"])
 
     def test_download_fallbacks_to_most_recent_when_no_latest_marked(self):
@@ -83,6 +84,7 @@ class DownloadResourceTest(BaseTestCase):
             # Assert
             self.assertEqual(200, response.status_code)
             self.assertIn("download_url", body)
+            self.assertTrue(body["download_url"].startswith("https"))
             self.assertIn("/new.json", body["download_url"])
 
     def test_download_returns_404_when_no_versions_exist(self):
@@ -160,6 +162,7 @@ class DownloadResourceTest(BaseTestCase):
             # Assert
             self.assertEqual(200, response.status_code)
             self.assertIn("download_url", body)
+            self.assertTrue(body["download_url"].startswith("https"))
             self.assertIn("/test.csv", body["download_url"])
 
             # Verify usage event was created in database
@@ -212,6 +215,7 @@ class DownloadResourceTest(BaseTestCase):
             # Assert
             self.assertEqual(200, response.status_code)
             self.assertIn("download_url", body)
+            self.assertTrue(body["download_url"].startswith("https"))
             self.assertIn("/metadata.json", body["download_url"])
 
             # Verify usage event was created with correct metadata

--- a/apps/publishers/tests/test_detail_publishers.py
+++ b/apps/publishers/tests/test_detail_publishers.py
@@ -36,7 +36,8 @@ class DetailPublisherTest(BaseTestCase):
         self.assertEqual("https://tafsircenter.org", body["website"])
         self.assertTrue(body["is_verified"])
         self.assertEqual("info@tafsircenter.org", body["contact_email"])
-        self.assertTrue(body["icon_url"].endswith("icons/tafsir-center.png"))
+        self.assertTrue(body["icon_url"].startswith("https"))
+        self.assertIn("icons/tafsir-center.png", body["icon_url"])
 
     def test_detail_publishers_where_publisher_does_not_exist_should_return_404(self):
         # Arrange

--- a/apps/publishers/views/publishers_detail.py
+++ b/apps/publishers/views/publishers_detail.py
@@ -1,5 +1,7 @@
 from django.shortcuts import get_object_or_404
 from ninja import Schema
+from pydantic import field_serializer
+from pydantic_core.core_schema import SerializationInfo
 
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
@@ -19,6 +21,14 @@ class DetailPublisherOut(Schema):
     is_verified: bool
     contact_email: str
     icon_url: str | None
+
+    @field_serializer("icon_url")
+    def serialize_icon_url(self, value, info: SerializationInfo) -> str:
+        request = info.context.get("request")
+        if request and isinstance(value, str) and not value.startswith("https"):
+            return request.build_absolute_uri(value)
+
+        return value if isinstance(value, str) else ""
 
 
 @router.get("publishers/{id}/", response=DetailPublisherOut, auth=None)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -122,7 +122,6 @@ LOCALE_PATHS = [BASE_DIR / "locale"]
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
-STATICFILES_DIRS = [str(APPS_DIR / "core" / "static")]
 
 # Media files
 MEDIA_URL = "/media/"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now return absolute HTTPS URLs for asset images, thumbnails, and downloads instead of relative paths for secure and direct resource access.

* **Tests**
  * Added validation to ensure download and asset URLs comply with HTTPS scheme across multiple endpoints.

* **Configuration**
  * Removed static files directory configuration entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->