### PR TITLE
increase Gunicorn timeout to 600 seconds (10 min) to consider large files upload

### DIFF
--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -35,4 +35,4 @@ else:
 fi
 
 echo "Starting Gunicorn server..."
-exec gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 120 config.wsgi
+exec gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 600 config.wsgi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased server request processing timeout from 120 to 600 seconds to allow more time for operations to complete before timing out.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->