### PR TITLE
feat: deploy R2 storage to staging

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -206,6 +206,11 @@ jobs:
                 echo "PGSSLMODE=require";
                 echo "ALLOWED_HOSTS=develop.api.cms.itqan.dev";
                 echo "CORS_ALLOWED_ORIGINS=https://dev.cms.itqan.dev,http://localhost:3000";
+                echo "CLOUDFLARE_R2_BUCKET=${{ secrets.DEVELOP_CLOUDFLARE_R2_BUCKET }}";
+                echo "CLOUDFLARE_R2_ENDPOINT=${{ secrets.CLOUDFLARE_R2_ENDPOINT }}";
+                echo "CLOUDFLARE_R2_ACCESS_KEY_ID=${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}";
+                echo "CLOUDFLARE_R2_SECRET_ACCESS_KEY=${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}";
+                echo "CLOUDFLARE_R2_PUBLIC_BASE_URL=${{ secrets.DEVELOP_CLOUDFLARE_R2_PUBLIC_BASE_URL }}";
               } > deployment/docker/.env
             elif [ "${{ env.ENV_NAME }}" = "staging" ]; then
               {
@@ -222,6 +227,11 @@ jobs:
                 echo "PGSSLMODE=require";
                 echo "ALLOWED_HOSTS=staging.api.cms.itqan.dev";
                 echo "CORS_ALLOWED_ORIGINS=https://staging.cms.itqan.dev,http://localhost:3000";
+                echo "CLOUDFLARE_R2_BUCKET=${{ secrets.STAGING_CLOUDFLARE_R2_BUCKET }}";
+                echo "CLOUDFLARE_R2_ENDPOINT=${{ secrets.CLOUDFLARE_R2_ENDPOINT }}";
+                echo "CLOUDFLARE_R2_ACCESS_KEY_ID=${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}";
+                echo "CLOUDFLARE_R2_SECRET_ACCESS_KEY=${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}";
+                echo "CLOUDFLARE_R2_PUBLIC_BASE_URL=${{ secrets.STAGING_CLOUDFLARE_R2_PUBLIC_BASE_URL }}";
               } > deployment/docker/.env
             elif [ "${{ env.ENV_NAME }}" = "production" ]; then
               {
@@ -238,6 +248,11 @@ jobs:
                 echo "PGSSLMODE=require";
                 echo "ALLOWED_HOSTS=api.cms.itqan.dev";
                 echo "CORS_ALLOWED_ORIGINS=https://cms.itqan.dev";
+                echo "CLOUDFLARE_R2_BUCKET=${{ secrets.PROD_CLOUDFLARE_R2_BUCKET }}";
+                echo "CLOUDFLARE_R2_ENDPOINT=${{ secrets.CLOUDFLARE_R2_ENDPOINT }}";
+                echo "CLOUDFLARE_R2_ACCESS_KEY_ID=${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}";
+                echo "CLOUDFLARE_R2_SECRET_ACCESS_KEY=${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}";
+                echo "CLOUDFLARE_R2_PUBLIC_BASE_URL=${{ secrets.PROD_CLOUDFLARE_R2_PUBLIC_BASE_URL }}";
               } > deployment/docker/.env
             fi
             # Append image coordinates for docker compose variable substitution

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -145,25 +145,36 @@ CLOUDFLARE_R2_ACCESS_KEY_ID = config("CLOUDFLARE_R2_ACCESS_KEY_ID", default="")
 CLOUDFLARE_R2_SECRET_ACCESS_KEY = config("CLOUDFLARE_R2_SECRET_ACCESS_KEY", default="")
 CLOUDFLARE_R2_PUBLIC_BASE_URL = config("CLOUDFLARE_R2_PUBLIC_BASE_URL", default="")
 
-CLOUDFLARE_R2_CONFIG_OPTIONS = {
-    "bucket_name": CLOUDFLARE_R2_BUCKET,
-    "endpoint_url": CLOUDFLARE_R2_ENDPOINT,
-    "access_key": CLOUDFLARE_R2_ACCESS_KEY_ID,
-    "secret_key": CLOUDFLARE_R2_SECRET_ACCESS_KEY,
-    "region_name": "auto",
-    "signature_version": "s3v4",
-}
-
-STORAGES = {
-    "default": {  # MEDIA
-        "BACKEND": "config.helpers.cloudflare.storages.MediaFileStorage",
-        "OPTIONS": CLOUDFLARE_R2_CONFIG_OPTIONS,
-    },
-    "staticfiles": {  # STATIC
-        "BACKEND": "config.helpers.cloudflare.storages.StaticFileStorage",
-        "OPTIONS": CLOUDFLARE_R2_CONFIG_OPTIONS,
-    },
-}
+# Use R2 if configured, otherwise fall back to local storage
+if CLOUDFLARE_R2_ENDPOINT:
+    CLOUDFLARE_R2_CONFIG_OPTIONS = {
+        "bucket_name": CLOUDFLARE_R2_BUCKET,
+        "endpoint_url": CLOUDFLARE_R2_ENDPOINT,
+        "access_key": CLOUDFLARE_R2_ACCESS_KEY_ID,
+        "secret_key": CLOUDFLARE_R2_SECRET_ACCESS_KEY,
+        "region_name": "auto",
+        "signature_version": "s3v4",
+    }
+    STORAGES = {
+        "default": {
+            "BACKEND": "config.helpers.cloudflare.storages.MediaFileStorage",
+            "OPTIONS": CLOUDFLARE_R2_CONFIG_OPTIONS,
+        },
+        "staticfiles": {
+            "BACKEND": "config.helpers.cloudflare.storages.StaticFileStorage",
+            "OPTIONS": CLOUDFLARE_R2_CONFIG_OPTIONS,
+        },
+    }
+else:
+    # Local storage for development without R2 credentials
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -75,17 +75,6 @@ SECURE_SSL_REDIRECT = False
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 
-# =========================
-# File Storage (local for development)
-# =========================
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    },
-}
 
 # =========================
 # OAuth providers (DB-backed)

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -84,29 +84,6 @@ CACHES = {
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
-# ============================================================
-# File Storage (Alibaba OSS)
-# ============================================================
-
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    },
-}
-
-AWS_S3_ENDPOINT_URL = config("OSS_ENDPOINT_URL", "")
-AWS_ACCESS_KEY_ID = config("OSS_ACCESS_KEY_ID", "")
-AWS_SECRET_ACCESS_KEY = config("OSS_SECRET_ACCESS_KEY", "")
-AWS_STORAGE_BUCKET_NAME = config("OSS_BUCKET_NAME", "itqan-cms")
-AWS_S3_REGION_NAME = config("OSS_REGION", "oss-me-east-1")
-AWS_S3_CUSTOM_DOMAIN = config("OSS_CUSTOM_DOMAIN", "")
-AWS_DEFAULT_ACL = "public-read"
-AWS_S3_OBJECT_PARAMETERS = {
-    "CacheControl": "max-age=86400",
-}
 
 # ============================================================
 # CSRF

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -89,19 +89,6 @@ CACHES = {
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
-# ============================================================
-# File Storage (local for staging)
-# ============================================================
-
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    },
-}
-
 # Media / Static
 MEDIA_URL = "/media/"
 MEDIA_ROOT = "/app/media"


### PR DESCRIPTION
## Summary
- Deploys Cloudflare R2 storage configuration to staging environment
- R2 credentials passed via GitHub Secrets
- Verified working on develop environment

## Changes
- Conditional R2/local storage logic in base.py
- CI/CD passes R2 env vars to all environments

## Test plan
- [x] Develop deployment verified healthy
- [ ] Staging health check passes
- [ ] File uploads work with R2 storage