### PR TITLE
feat: add internal Search Reciters API with pagination and filtering (closes #193)

### DIFF
--- a/apps/content/api/internal/reciter_list.py
+++ b/apps/content/api/internal/reciter_list.py
@@ -1,9 +1,12 @@
+from typing import Literal
+
 from ninja import FilterSchema, Query, Schema
 from ninja.pagination import paginate
 from pydantic import Field
 
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
+from apps.core.ninja_utils.errors import NinjaErrorResponse
 from apps.core.ninja_utils.ordering_base import ordering
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
@@ -16,6 +19,7 @@ router = ItqanRouter(tags=[NinjaTag.RECITERS])
 class ReciterOut(Schema):
     id: int
     name: str
+    name_ar: str = ""
     recitations_count: int = Field(
         0, description="Number of READY recitation assets for this reciter"
     )
@@ -29,7 +33,13 @@ class ReciterFilter(FilterSchema):
     )
 
 
-@router.get("reciters/", response=list[ReciterOut])
+@router.get(
+    "reciters/",
+    response={
+        200: list[ReciterOut],
+        400: NinjaErrorResponse[Literal["bad_request"], Literal[None]],
+    },
+)
 @paginate
 @ordering(ordering_fields=["name"])
 @searching(search_fields=["name", "name_ar", "slug"])
@@ -45,5 +55,5 @@ def list_reciters(request: Request, filters: ReciterFilter = Query()):  # noqa: 
     repo = RecitationRepository()
     service = RecitationService(repo)
     publisher_q = request.publisher_q("assets__resource__publisher")
-    qs = service.get_all_reciters(publisher_q, filters)
-    return qs
+    qs = service.get_all_reciters(publisher_q)
+    return filters.filter(qs)


### PR DESCRIPTION
This PR implements the Search Reciters API endpoint for Issue #193.

### Features:
- New GET /reciters/ endpoint in the internal API
- Text search support for reciter name and slug
- Publisher filtering via publisher_id parameter
- Server-side pagination with page and page_size parameters
- Ordering support via ordering parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to list reciters, returning id, name and recitations_count.
  * Supports full-text search (name/slug), filtering by publisher ID, server-side pagination, and ordering by name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->