### PR TITLE
exclude draft resources from listing in cms website

### DIFF
--- a/apps/content/api/internal/assets_list.py
+++ b/apps/content/api/internal/assets_list.py
@@ -37,6 +37,8 @@ class AssetFilter(FilterSchema):
 @ordering(ordering_fields=["name", "category"])
 @searching(search_fields=["name", "description", "resource__publisher__name", "category"])
 def list_assets(request: Request, filters: AssetFilter = Query()):
-    assets = Asset.objects.filter(request.publisher_q("resource__publisher"))
+    assets = Asset.objects.filter(request.publisher_q("resource__publisher")).exclude(
+        resource__status=Resource.StatusChoice.DRAFT
+    )
     assets = filters.filter(assets)
     return assets

--- a/apps/content/tests/internal/test_assets_access.py
+++ b/apps/content/tests/internal/test_assets_access.py
@@ -18,6 +18,7 @@ class AssetAccessTest(BaseTestCase):
             description="Test asset description",
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC_BY_SA,
+            resource__status=Resource.StatusChoice.READY,
         )
         self.user = baker.make(User, email="test@example.com")
 

--- a/apps/content/tests/internal/test_assets_detail.py
+++ b/apps/content/tests/internal/test_assets_detail.py
@@ -19,6 +19,7 @@ class DetailAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC_BY_SA,
             thumbnail_url="thumbnails/tafseer.png",
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -50,6 +51,7 @@ class DetailAssetTest(BaseTestCase):
             license=LicenseChoice.CC_BY,
             category=Resource.CategoryChoice.MUSHAF,
             thumbnail_url="thumbs/schema.png",
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -87,6 +89,7 @@ class DetailAssetTest(BaseTestCase):
                 category=Resource.CategoryChoice.TAFSIR,
                 license=LicenseChoice.CC0,
                 thumbnail_url="thumbs/tafsir.png",
+                resource__status=Resource.StatusChoice.READY,
             ),
             baker.make(
                 Asset,
@@ -97,6 +100,7 @@ class DetailAssetTest(BaseTestCase):
                 thumbnail_url="thumbs/recitation.png",
                 reciter=baker.make("content.Reciter", name="Test Reciter"),
                 riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+                resource__status=Resource.StatusChoice.READY,
             ),
             baker.make(
                 Asset,
@@ -105,6 +109,7 @@ class DetailAssetTest(BaseTestCase):
                 category=Resource.CategoryChoice.MUSHAF,
                 license=LicenseChoice.CC0,
                 thumbnail_url="thumbs/mushaf.png",
+                resource__status=Resource.StatusChoice.READY,
             ),
         ]
 
@@ -134,6 +139,7 @@ class DetailAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC0,
             thumbnail_url="thumbs/localized.png",
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -160,6 +166,7 @@ class DetailAssetTest(BaseTestCase):
             thumbnail_url="thumbs/en-only.png",
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -213,6 +220,7 @@ class DetailAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC_BY,
             thumbnail_url="thumbnails/test.png",
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -250,6 +258,7 @@ class DetailAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.MUSHAF,
             license=LicenseChoice.CC0,
             thumbnail_url="thumbnails/anonymous.png",
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -281,6 +290,7 @@ class DetailAssetTest(BaseTestCase):
             thumbnail_url="thumbnails/metadata.png",
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act - Include custom headers
@@ -322,6 +332,7 @@ class DetailAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC0,
             thumbnail_url=None,  # Test the optional field
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act

--- a/apps/content/tests/internal/test_assets_download.py
+++ b/apps/content/tests/internal/test_assets_download.py
@@ -30,6 +30,7 @@ class TestAssetDownload(BaseTestCase):
             description="Test asset description",
             category=Resource.CategoryChoice.TAFSIR,
             license=LicenseChoice.CC_BY_SA,
+            resource__status=Resource.StatusChoice.READY,
         )
         self.user = baker.make(User, email="test@example.com")
 

--- a/apps/content/tests/internal/test_assets_list.py
+++ b/apps/content/tests/internal/test_assets_list.py
@@ -7,7 +7,12 @@ from apps.core.tests import BaseTestCase
 class ListAssetTest(BaseTestCase):
     def test_list_asset_should_return_all_available_assets(self):
         # Arrange
-        baker.make(Asset, name="Tafsir Ibn Katheer", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset,
+            name="Tafsir Ibn Katheer",
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
+        )
 
         # Act
         response = self.client.get("/cms-api/assets/", format="json")
@@ -21,10 +26,18 @@ class ListAssetTest(BaseTestCase):
     def test_list_asset_filter_by_license_code_should_return_filtered_assets(self):
         # Arrange
         baker.make(
-            Asset, name="Tafsir Al-Jalalayn", license=LicenseChoice.CC_BY_SA, category=Resource.CategoryChoice.TAFSIR
+            Asset,
+            name="Tafsir Al-Jalalayn",
+            license=LicenseChoice.CC_BY_SA,
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
         )
         baker.make(
-            Asset, name="Tafsir Ibn Katheer", license=LicenseChoice.CC_BY_NC, category=Resource.CategoryChoice.TAFSIR
+            Asset,
+            name="Tafsir Ibn Katheer",
+            license=LicenseChoice.CC_BY_NC,
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -38,13 +51,19 @@ class ListAssetTest(BaseTestCase):
 
     def test_list_asset_filter_by_category_should_return_filtered_assets(self):
         # Arrange
-        baker.make(Asset, name="Tafsir Al-Jalalayn", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset,
+            name="Tafsir Al-Jalalayn",
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
+        )
         baker.make(
             Asset,
             name="Muhammad Refaat",
             category=Resource.CategoryChoice.RECITATION,
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Act
@@ -64,15 +83,26 @@ class ListAssetTest(BaseTestCase):
         self,
     ):
         # Arrange
-        baker.make(Asset, name="Tafsir Al-Jalalayn", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset,
+            name="Tafsir Al-Jalalayn",
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
+        )
         baker.make(
             Asset,
             name="Muhammad Refaat",
             category=Resource.CategoryChoice.RECITATION,
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
-        baker.make(Asset, name="King Fahd", category=Resource.CategoryChoice.MUSHAF)
+        baker.make(
+            Asset,
+            name="King Fahd",
+            category=Resource.CategoryChoice.MUSHAF,
+            resource__status=Resource.StatusChoice.READY,
+        )
 
         # Act
         response = self.client.get(
@@ -88,9 +118,15 @@ class ListAssetTest(BaseTestCase):
 
     def test_list_order_by_name_descending_should_return_sorted_assets(self):
         # Arrange
-        baker.make(Asset, name="A", category=Resource.CategoryChoice.TAFSIR)
-        baker.make(Asset, name="C", category=Resource.CategoryChoice.TAFSIR)
-        baker.make(Asset, name="B", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset, name="A", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
+        baker.make(
+            Asset, name="C", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
+        baker.make(
+            Asset, name="B", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
 
         # Act
         response = self.client.get("/cms-api/assets/", data={"ordering": "-name"}, format="json")
@@ -105,9 +141,15 @@ class ListAssetTest(BaseTestCase):
 
     def test_list_order_by_name_ascending_should_return_sorted_assets(self):
         # Arrange
-        baker.make(Asset, name="A", category=Resource.CategoryChoice.TAFSIR)
-        baker.make(Asset, name="C", category=Resource.CategoryChoice.TAFSIR)
-        baker.make(Asset, name="B", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset, name="A", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
+        baker.make(
+            Asset, name="C", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
+        baker.make(
+            Asset, name="B", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
 
         # Act
         response = self.client.get("/cms-api/assets/", data={"ordering": "name"}, format="json")
@@ -122,15 +164,20 @@ class ListAssetTest(BaseTestCase):
 
     def test_list_assets_order_by_category_descending_should_return_sorted_assets(self):
         # Arrange
-        baker.make(Asset, name="A", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset, name="A", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
         baker.make(
             Asset,
             name="C",
             category=Resource.CategoryChoice.RECITATION,
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
-        baker.make(Asset, name="B", category=Resource.CategoryChoice.TAFSIR)
+        baker.make(
+            Asset, name="B", category=Resource.CategoryChoice.TAFSIR, resource__status=Resource.StatusChoice.READY
+        )
 
         # Act
         response = self.client.get("/cms-api/assets/", data={"ordering": "-category"}, format="json")
@@ -153,6 +200,7 @@ class ListAssetTest(BaseTestCase):
             name="Tafsir Al-Jalalayn",
             description="This is a tafsir book",
             category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
         )
         baker.make(
             Asset,
@@ -161,12 +209,14 @@ class ListAssetTest(BaseTestCase):
             category=Resource.CategoryChoice.RECITATION,
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            resource__status=Resource.StatusChoice.READY,
         )
         baker.make(
             Asset,
             name="King Fahd",
             description="This is a mushaf book",
             category=Resource.CategoryChoice.MUSHAF,
+            resource__status=Resource.StatusChoice.READY,
         )
 
         # Test search by name/category
@@ -182,3 +232,27 @@ class ListAssetTest(BaseTestCase):
         response_body = response.json()
         self.assertEqual(1, len(response_body["results"]))
         self.assertEqual("Muhammad Refaat", response_body["results"][0]["name"])
+
+    def test_list_assets_should_exclude_assets_with_draft_resource(self):
+        # Arrange
+        baker.make(
+            Asset,
+            name="Ready Asset",
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.READY,
+        )
+        baker.make(
+            Asset,
+            name="Draft Asset",
+            category=Resource.CategoryChoice.TAFSIR,
+            resource__status=Resource.StatusChoice.DRAFT,
+        )
+
+        # Act
+        response = self.client.get("/cms-api/assets/", format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        response_body = response.json()
+        self.assertEqual(1, len(response_body["results"]))
+        self.assertEqual("Ready Asset", response_body["results"][0]["name"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assets tied to draft resources are now excluded from listings and search results so only finalized content appears.
* **Tests**
  * Coverage improved to verify draft assets are excluded and ready assets appear correctly in listing, filtering, sorting, and detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->