### PR TITLE
perf: add missing database indexes on high-query fields

### DIFF
--- a/apps/content/migrations/0027_usageevent_indexes.py
+++ b/apps/content/migrations/0027_usageevent_indexes.py
@@ -4,40 +4,46 @@ UsageEvent: composite indexes for stats aggregation queries that filter by
 created_at + usage_kind and developer_user + usage_kind. Also individual
 indexes on asset_id and resource_id which are PositiveIntegerFields (not FKs)
 and thus lack Django's automatic FK indexing.
+
+Uses AddIndexConcurrently to avoid blocking writes during index creation
+on PostgreSQL. Requires atomic = False.
 """
 
+from django.contrib.postgres.operations import AddIndexConcurrently
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+
+    atomic = False
 
     dependencies = [
         ("content", "0026_reciter_bio_ar_reciter_bio_en_riwayah_bio_and_more"),
     ]
 
     operations = [
-        migrations.AddIndex(
+        AddIndexConcurrently(
             model_name="usageevent",
             index=models.Index(
                 fields=["created_at", "usage_kind"],
                 name="usageevent_created_kind_idx",
             ),
         ),
-        migrations.AddIndex(
+        AddIndexConcurrently(
             model_name="usageevent",
             index=models.Index(
                 fields=["developer_user", "usage_kind"],
                 name="usageevent_user_kind_idx",
             ),
         ),
-        migrations.AddIndex(
+        AddIndexConcurrently(
             model_name="usageevent",
             index=models.Index(
                 fields=["asset_id"],
                 name="usageevent_asset_id_idx",
             ),
         ),
-        migrations.AddIndex(
+        AddIndexConcurrently(
             model_name="usageevent",
             index=models.Index(
                 fields=["resource_id"],

--- a/apps/content/migrations/0027_usageevent_indexes.py
+++ b/apps/content/migrations/0027_usageevent_indexes.py
@@ -1,0 +1,47 @@
+"""Add missing database indexes on high-query fields.
+
+UsageEvent: composite indexes for stats aggregation queries that filter by
+created_at + usage_kind and developer_user + usage_kind. Also individual
+indexes on asset_id and resource_id which are PositiveIntegerFields (not FKs)
+and thus lack Django's automatic FK indexing.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("content", "0026_reciter_bio_ar_reciter_bio_en_riwayah_bio_and_more"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="usageevent",
+            index=models.Index(
+                fields=["created_at", "usage_kind"],
+                name="usageevent_created_kind_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usageevent",
+            index=models.Index(
+                fields=["developer_user", "usage_kind"],
+                name="usageevent_user_kind_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usageevent",
+            index=models.Index(
+                fields=["asset_id"],
+                name="usageevent_asset_id_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usageevent",
+            index=models.Index(
+                fields=["resource_id"],
+                name="usageevent_resource_id_idx",
+            ),
+        ),
+    ]

--- a/apps/content/models.py
+++ b/apps/content/models.py
@@ -533,6 +533,12 @@ class UsageEvent(BaseModel):
                 name="usage_event_subject_kind_consistency",
             )
         ]
+        indexes = [
+            models.Index(fields=["created_at", "usage_kind"], name="usageevent_created_kind_idx"),
+            models.Index(fields=["developer_user", "usage_kind"], name="usageevent_user_kind_idx"),
+            models.Index(fields=["asset_id"], name="usageevent_asset_id_idx"),
+            models.Index(fields=["resource_id"], name="usageevent_resource_id_idx"),
+        ]
 
     def __str__(self):
         return f"UsageEvent(user={self.developer_user_id}, kind={self.usage_kind}, subject={self.subject_kind})"


### PR DESCRIPTION
## Summary

Closes #219

Adds database indexes to `UsageEvent` for stats aggregation queries that currently do full table scans.

## Analysis

### What was already indexed (Django ForeignKey auto-creates indexes):
- `Asset.resource` (FK) — auto-indexed
- `AssetAccessRequest.asset` (FK) — auto-indexed
- `AssetAccess.user` + `AssetAccess.asset` — **unique composite index** via `unique_together = ["user", "asset"]`
- `UsageEvent.developer_user` (FK) — auto-indexed

### What was NOT indexed (the actual gap):
- `UsageEvent.asset_id` — **PositiveIntegerField**, not a ForeignKey, so no auto-index
- `UsageEvent.resource_id` — same, plain integer field
- No composite indexes for the stats queries in `tasks.py` that filter by `created_at__date + usage_kind`

## Changes

### Model changes (`apps/content/models.py`)
Added `Meta.indexes` to `UsageEvent`:

| Index | Fields | Covers |
|-------|--------|--------|
| `usageevent_created_kind_idx` | `(created_at, usage_kind)` | Daily stats: `filter(created_at__date=today, usage_kind="file_download")` |
| `usageevent_user_kind_idx` | `(developer_user, usage_kind)` | Per-user stats: `filter(developer_user=user).values("usage_kind")` |
| `usageevent_asset_id_idx` | `(asset_id)` | Asset-level stats: `filter(asset_id=X)` |
| `usageevent_resource_id_idx` | `(resource_id)` | Resource-level stats: `filter(resource_id=X)` |

### Migration (`0027_usageevent_indexes.py`)
Forward-only migration with 4 `AddIndex` operations. Safe to run on production — `CREATE INDEX` on empty/small tables is instant, and on larger tables PostgreSQL creates indexes without locking writes.

## Design decisions

- **Did NOT add redundant `db_index=True` to ForeignKey fields**: Django ForeignKey already defaults to `db_index=True`. Adding it explicitly would generate an empty migration.
- **Focused on UsageEvent**: This is the only model where the indexed columns are plain integer fields (not FKs) and where composite indexes are needed for aggregation queries.
- **Composite indexes ordered for query patterns**: `(created_at, usage_kind)` matches the daily stats query pattern in `aggregate_daily_stats_task`.

## Test plan

- [x] Migration file created and dependency chain is correct
- [ ] `python manage.py migrate` applies cleanly
- [ ] `EXPLAIN ANALYZE` on `UsageEvent.objects.filter(created_at__date=today, usage_kind='file_download')` shows Index Scan

🌙 Ramadan Al-Athar Contribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database performance for usage event tracking by adding new indexes to speed up common queries (created time & kind, user & kind, asset ID, resource ID), reducing latency for reporting and analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->