### PR TITLE
Fix N+1 queries in recitation list endpoint

### DIFF
--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -24,7 +24,7 @@ class RecitationRepository(BaseRecitationRepository):
         """
         Returns a queryset of Asset objects.
         """
-        qs = self.asset_model.objects.select_related("resource", "reciter", "riwayah").filter(
+        qs = self.asset_model.objects.select_related("resource", "reciter", "riwayah", "qiraah").filter(
             publisher_q,
             category=Resource.CategoryChoice.RECITATION,
             resource__category=Resource.CategoryChoice.RECITATION,

--- a/apps/content/tests/tenant/test_recitation_list.py
+++ b/apps/content/tests/tenant/test_recitation_list.py
@@ -1,7 +1,8 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
 
-from apps.content.models import Asset, RecitationSurahTrack, Reciter, Resource, Riwayah
+from apps.content.models import Asset, Qiraah, RecitationSurahTrack, Reciter, Resource, Riwayah
 from apps.core.tests import BaseTestCase
 from apps.publishers.models import Publisher
 from apps.users.models import User
@@ -270,3 +271,61 @@ class RecitationsListTest(BaseTestCase):
         names = {item["name"] for item in items}
         self.assertIn("Silah Recitation", names)
         self.assertNotIn("Skoun Recitation", names)
+
+
+class RecitationListQueryCountTest(BaseTestCase):
+    """Regression test: recitation list must batch-load all related models (no N+1)."""
+
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher, name="Publisher")
+        self.domain = baker.make(
+            "publishers.Domain",
+            domain="querytest.com",
+            publisher=self.publisher,
+            is_primary=True,
+        )
+        self.user = User.objects.create_user(email="querycount@example.com", name="QC User")
+
+        qiraah = baker.make(Qiraah, name="Qiraah Asim")
+        riwayah = baker.make(Riwayah, qiraah=qiraah)
+        reciter = baker.make(Reciter, name="Reciter A")
+        resource = baker.make(
+            Resource,
+            publisher=self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.READY,
+        )
+
+        # Create several assets to expose N+1 problems
+        for i in range(5):
+            baker.make(
+                Asset,
+                category=Resource.CategoryChoice.RECITATION,
+                resource=resource,
+                reciter=reciter,
+                riwayah=riwayah,
+                qiraah=qiraah,
+                name=f"Recitation {i}",
+            )
+
+    def test_recitation_list_query_count_lte_4(self):
+        """The recitation list endpoint must use 4 or fewer DB queries."""
+        from django.db import connection
+
+        self.authenticate_user(self.user, domain=self.domain)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get("/tenant/recitations/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(5, len(items))
+
+        # Must not exceed 4 queries (auth + count + data + at most 1 extra)
+        self.assertLessEqual(
+            len(ctx),
+            4,
+            f"Expected ≤4 queries but got {len(ctx)}. Queries:\n"
+            + "\n".join(f"  {i+1}. {q['sql'][:120]}" for i, q in enumerate(ctx.captured_queries)),
+        )


### PR DESCRIPTION
## Summary
- Added `"qiraah"` to `select_related()` in `list_recitations_qs()` to eliminate N+1 queries when the serializer accesses the qiraah relationship
- Audited `list_riwayahs_qs()` — line 169 already includes `select_related("qiraah")`, confirmed no N+1 there
- Added a `CaptureQueriesContext` regression test asserting the recitation list endpoint uses ≤4 DB queries

## Problem
The recitation list endpoint eager-loaded `resource`, `reciter`, and `riwayah` via `select_related()` but missed `qiraah`. Since `RecitationListOut` accesses `qiraah: RecitationQiraahOut`, Django issued a separate query per recitation row — turning a 2-query page load into 50+ queries for a full page.

## Changes
| File | Change |
|------|--------|
| `apps/content/repositories/recitation.py` | Added `"qiraah"` to `select_related()` call |
| `apps/content/tests/tenant/test_recitation_list.py` | Added `RecitationListQueryCountTest` with `CaptureQueriesContext` |

## Test plan
- [ ] Existing recitation list tests still pass
- [ ] New `test_recitation_list_query_count_lte_4` passes — asserts ≤4 queries for 5 recitations with qiraah data
- [ ] Verify all 3 endpoints (tenant, public, internal) benefit since they share `list_recitations_qs()`

Closes #220