### PR TITLE
Add recitation statistics endpoint with Redis caching

### DIFF
--- a/apps/content/api/tenant/recitation_statistics.py
+++ b/apps/content/api/tenant/recitation_statistics.py
@@ -1,0 +1,26 @@
+from ninja import Schema
+
+from apps.content.repositories.recitation import RecitationRepository
+from apps.content.services.recitation import RecitationService
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+
+router = ItqanRouter(tags=[NinjaTag.RECITATIONS])
+
+
+class RecitationStatisticsOut(Schema):
+    total_recitations: int
+    total_reciters: int
+    total_riwayahs: int
+
+
+@router.get("recitation-statistics/", response=RecitationStatisticsOut)
+def get_recitation_statistics(request: Request):
+    repo = RecitationRepository()
+    service = RecitationService(repo)
+
+    publisher_q = request.publisher_q("resource__publisher")
+    publisher_id = request.publisher.id if request.publisher else None
+
+    return service.get_recitation_statistics(publisher_q, publisher_id=publisher_id)

--- a/apps/content/repositories/base.py
+++ b/apps/content/repositories/base.py
@@ -55,3 +55,10 @@ class BaseRecitationRepository(ABC):
         Returns a queryset of Qiraah objects that have READY recitation assets through riwayahs.
         """
         pass
+
+    @abstractmethod
+    def get_recitation_statistics(self, publisher_q: Q) -> dict[str, int]:
+        """
+        Returns aggregate statistics for the recitation library.
+        """
+        pass

--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -234,3 +234,50 @@ class RecitationRepository(BaseRecitationRepository):
                 qs = qs.filter(slug__icontains=slug)
 
         return qs
+
+    def get_recitation_statistics(self, publisher_q: Q) -> dict[str, int]:
+        """
+        Returns aggregate statistics for the recitation library scoped to a publisher.
+        """
+        base_filter = Q(
+            category=Resource.CategoryChoice.RECITATION,
+            resource__category=Resource.CategoryChoice.RECITATION,
+            resource__status=Resource.StatusChoice.READY,
+        )
+
+        recitations_count = self.asset_model.objects.filter(publisher_q, base_filter).count()
+
+        reciters_count = (
+            Reciter.objects.filter(is_active=True)
+            .filter(
+                Q(
+                    assets__category=Resource.CategoryChoice.RECITATION,
+                    assets__resource__category=Resource.CategoryChoice.RECITATION,
+                    assets__resource__status=Resource.StatusChoice.READY,
+                )
+                & publisher_q
+            )
+            .distinct()
+            .count()
+        )
+
+        riwayahs_count = (
+            self.riwayah_model.objects.filter(is_active=True)
+            .filter(
+                Q(
+                    assets__category=Resource.CategoryChoice.RECITATION,
+                    assets__riwayah__isnull=False,
+                    assets__resource__category=Resource.CategoryChoice.RECITATION,
+                    assets__resource__status=Resource.StatusChoice.READY,
+                )
+                & publisher_q
+            )
+            .distinct()
+            .count()
+        )
+
+        return {
+            "total_recitations": recitations_count,
+            "total_reciters": reciters_count,
+            "total_riwayahs": riwayahs_count,
+        }

--- a/apps/content/services/recitation.py
+++ b/apps/content/services/recitation.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
+
+from django.core.cache import cache
 
 if TYPE_CHECKING:
     from django.db.models import Q, QuerySet
 
     from apps.content.models import Asset, RecitationSurahTrack
     from apps.content.repositories.base import BaseRecitationRepository
+
+logger = logging.getLogger(__name__)
+
+STATS_CACHE_TTL = 60 * 5  # 5 minutes
 
 
 class RecitationService:
@@ -44,3 +51,17 @@ class RecitationService:
         filters_dict = filters.model_dump(exclude_none=True) if filters and hasattr(filters, "model_dump") else {}
 
         return self.repo.list_reciters_qs(publisher_q, filters_dict=filters_dict)
+
+    def get_recitation_statistics(self, publisher_q: Q, publisher_id: int | None = None) -> dict[str, int]:
+        """
+        Business Logic: Return cached aggregate statistics for the recitation library.
+        Cache is keyed per publisher to maintain tenant isolation.
+        """
+        cache_key = f"recitation_stats-{publisher_id or 'all'}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        stats = self.repo.get_recitation_statistics(publisher_q)
+        cache.set(cache_key, stats, timeout=STATS_CACHE_TTL)
+        return stats

--- a/apps/content/tests/tenant/test_recitation_statistics.py
+++ b/apps/content/tests/tenant/test_recitation_statistics.py
@@ -1,0 +1,146 @@
+from unittest.mock import patch
+
+from model_bakery import baker
+
+from apps.content.models import Asset, Qiraah, Reciter, Resource, Riwayah
+from apps.core.tests import BaseTestCase
+from apps.publishers.models import Publisher
+from apps.users.models import User
+
+
+class RecitationStatisticsTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher, name="Publisher One")
+        self.domain = baker.make(
+            "publishers.Domain",
+            domain="stats-test.com",
+            publisher=self.publisher,
+            is_primary=True,
+        )
+        self.user = User.objects.create_user(email="stats@example.com", name="Stats User")
+
+    def _make_ready_resource(self, publisher=None):
+        return baker.make(
+            Resource,
+            publisher=publisher or self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.READY,
+        )
+
+    def _make_recitation_asset(self, resource, reciter, riwayah=None, qiraah=None):
+        return baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=resource,
+            reciter=reciter,
+            riwayah=riwayah,
+            qiraah=qiraah,
+        )
+
+    def test_statistics_returns_correct_counts(self):
+        qiraah = baker.make(Qiraah, name="Qiraah Asim")
+        riwayah1 = baker.make(Riwayah, qiraah=qiraah)
+        riwayah2 = baker.make(Riwayah, qiraah=qiraah)
+        reciter1 = baker.make(Reciter, name="Reciter A", is_active=True)
+        reciter2 = baker.make(Reciter, name="Reciter B", is_active=True)
+        resource = self._make_ready_resource()
+
+        # 3 recitations, 2 reciters, 2 riwayahs
+        self._make_recitation_asset(resource, reciter1, riwayah1, qiraah)
+        self._make_recitation_asset(resource, reciter1, riwayah2, qiraah)
+        self._make_recitation_asset(resource, reciter2, riwayah1, qiraah)
+
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitation-statistics/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        self.assertEqual(3, data["total_recitations"])
+        self.assertEqual(2, data["total_reciters"])
+        self.assertEqual(2, data["total_riwayahs"])
+
+    def test_statistics_excludes_draft_resources(self):
+        reciter = baker.make(Reciter, name="Reciter X", is_active=True)
+        riwayah = baker.make(Riwayah)
+
+        ready_resource = self._make_ready_resource()
+        draft_resource = baker.make(
+            Resource,
+            publisher=self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.DRAFT,
+        )
+
+        self._make_recitation_asset(ready_resource, reciter, riwayah)
+        self._make_recitation_asset(draft_resource, reciter, riwayah)
+
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitation-statistics/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        # Only the READY resource asset should count
+        self.assertEqual(1, data["total_recitations"])
+
+    def test_statistics_scoped_to_publisher(self):
+        other_publisher = baker.make(Publisher, name="Other Publisher")
+        reciter = baker.make(Reciter, name="Reciter Y", is_active=True)
+        riwayah = baker.make(Riwayah)
+
+        my_resource = self._make_ready_resource(self.publisher)
+        other_resource = self._make_ready_resource(other_publisher)
+
+        self._make_recitation_asset(my_resource, reciter, riwayah)
+        self._make_recitation_asset(other_resource, reciter, riwayah)
+
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitation-statistics/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        self.assertEqual(1, data["total_recitations"])
+
+    def test_statistics_empty_when_no_recitations(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitation-statistics/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        self.assertEqual(0, data["total_recitations"])
+        self.assertEqual(0, data["total_reciters"])
+        self.assertEqual(0, data["total_riwayahs"])
+
+    def test_statistics_are_cached(self):
+        reciter = baker.make(Reciter, name="Reciter Z", is_active=True)
+        riwayah = baker.make(Riwayah)
+        resource = self._make_ready_resource()
+        self._make_recitation_asset(resource, reciter, riwayah)
+
+        self.authenticate_user(self.user, domain=self.domain)
+
+        # First call populates cache
+        response1 = self.client.get("/tenant/recitation-statistics/")
+        self.assertEqual(200, response1.status_code)
+
+        # Second call should return same data from cache
+        with patch(
+            "apps.content.repositories.recitation.RecitationRepository.get_recitation_statistics"
+        ) as mock_stats:
+            response2 = self.client.get("/tenant/recitation-statistics/")
+            self.assertEqual(200, response2.status_code)
+            # The repo method should NOT be called — cache should serve the response
+            mock_stats.assert_not_called()
+
+        self.assertEqual(response1.json(), response2.json())
+
+    def test_statistics_response_shape(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitation-statistics/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        self.assertIn("total_recitations", data)
+        self.assertIn("total_reciters", data)
+        self.assertIn("total_riwayahs", data)
+        self.assertEqual(3, len(data))


### PR DESCRIPTION
## Summary
- New `GET /tenant/recitation-statistics/` endpoint returning aggregate counts: total recitations, reciters, and riwayahs
- Results cached in Redis with 5-minute TTL, keyed per publisher for tenant isolation
- Follows existing Django Ninja patterns (auto-discovered router, service/repository layers)

## Architecture

```
API Endpoint → RecitationService.get_recitation_statistics()
                  ├── cache.get() → return if hit
                  └── RecitationRepository.get_recitation_statistics()
                        ├── Asset.count() (READY recitation assets)
                        ├── Reciter.count() (distinct, with READY assets)
                        └── Riwayah.count() (distinct, with READY assets)
                      → cache.set(result, TTL=300s)
```

## Response Shape
```json
{
  "total_recitations": 42,
  "total_reciters": 8,
  "total_riwayahs": 3
}
```

## Files Changed
| File | Change |
|------|--------|
| `apps/content/api/tenant/recitation_statistics.py` | New endpoint (auto-discovered) |
| `apps/content/services/recitation.py` | Added `get_recitation_statistics()` with cache layer |
| `apps/content/repositories/recitation.py` | Added `get_recitation_statistics()` with 3 COUNT queries |
| `apps/content/repositories/base.py` | Added abstract method to base class |
| `apps/content/tests/tenant/test_recitation_statistics.py` | 6 test cases |

## Test Plan
- [ ] `test_statistics_returns_correct_counts` — 3 assets, 2 reciters, 2 riwayahs
- [ ] `test_statistics_excludes_draft_resources` — only READY resources counted
- [ ] `test_statistics_scoped_to_publisher` — tenant isolation verified
- [ ] `test_statistics_empty_when_no_recitations` — returns all zeros
- [ ] `test_statistics_are_cached` — second call skips DB (mock verifies)
- [ ] `test_statistics_response_shape` — exactly 3 keys in response

Closes #188