### PR TITLE
Enable bilingual Arabic+English search for recitations

### DIFF
--- a/apps/content/api/internal/recitation_list.py
+++ b/apps/content/api/internal/recitation_list.py
@@ -51,7 +51,20 @@ class RecitationFilter(FilterSchema):
 @router.get("recitations/", response=list[RecitationListOut])
 @paginate
 @ordering(ordering_fields=["name", "created_at", "updated_at"])
-@searching(search_fields=["name", "description", "resource__publisher__name", "reciter__name"])
+@searching(
+    search_fields=[
+        "name",
+        "name_ar",
+        "description",
+        "resource__publisher__name",
+        "reciter__name",
+        "reciter__name_ar",
+        "riwayah__name",
+        "riwayah__name_ar",
+        "qiraah__name",
+        "qiraah__name_ar",
+    ]
+)
 def list_recitations(request: Request, filters: RecitationFilter = Query()):
     repo = RecitationRepository()
     service = RecitationService(repo)

--- a/apps/content/api/public/recitation_list.py
+++ b/apps/content/api/public/recitation_list.py
@@ -74,7 +74,20 @@ class RecitationFilter(FilterSchema):
 @router.get("recitations/", response=list[RecitationListOut])
 @paginate
 @ordering(ordering_fields=["name", "created_at", "updated_at"])
-@searching(search_fields=["name", "description", "resource__publisher__name", "reciter__name"])
+@searching(
+    search_fields=[
+        "name",
+        "name_ar",
+        "description",
+        "resource__publisher__name",
+        "reciter__name",
+        "reciter__name_ar",
+        "riwayah__name",
+        "riwayah__name_ar",
+        "qiraah__name",
+        "qiraah__name_ar",
+    ]
+)
 def list_recitations(request, filters: RecitationFilter = Query()):
     repo = RecitationRepository()
     service = RecitationService(repo)

--- a/apps/content/api/tenant/qiraah_list.py
+++ b/apps/content/api/tenant/qiraah_list.py
@@ -39,7 +39,7 @@ class QiraahFilter(FilterSchema):
 @router.get("qiraahs/", response=list[QiraahOut])
 @paginate
 @ordering(ordering_fields=["name"])
-@searching(search_fields=["name", "slug"])
+@searching(search_fields=["name", "name_ar", "slug"])
 def list_qiraahs(request: Request, filters: QiraahFilter = Query()):
     """
     List qiraahs (recitation methods) that have at least one active riwayah

--- a/apps/content/api/tenant/recitation_list.py
+++ b/apps/content/api/tenant/recitation_list.py
@@ -53,7 +53,20 @@ class RecitationFilter(FilterSchema):
 @router.get("recitations/", response=list[RecitationListOut])
 @paginate
 @ordering(ordering_fields=["name", "created_at", "updated_at"])
-@searching(search_fields=["name", "description", "resource__publisher__name", "reciter__name"])
+@searching(
+    search_fields=[
+        "name",
+        "name_ar",
+        "description",
+        "resource__publisher__name",
+        "reciter__name",
+        "reciter__name_ar",
+        "riwayah__name",
+        "riwayah__name_ar",
+        "qiraah__name",
+        "qiraah__name_ar",
+    ]
+)
 def list_recitations(request: Request, filters: RecitationFilter = Query()):
     repo = RecitationRepository()
     service = RecitationService(repo)

--- a/apps/content/api/tenant/riwayah_list.py
+++ b/apps/content/api/tenant/riwayah_list.py
@@ -38,7 +38,7 @@ class RiwayahFilter(FilterSchema):
 @router.get("riwayahs/", response=list[RiwayahOut])
 @paginate
 @ordering(ordering_fields=["name"])
-@searching(search_fields=["name", "slug"])
+@searching(search_fields=["name", "name_ar", "slug"])
 def list_riwayahs(request: Request, filters: RiwayahFilter = Query()):
     """
     List riwayahs that have at least one READY recitation Asset.

--- a/apps/content/tests/tenant/test_recitation_list.py
+++ b/apps/content/tests/tenant/test_recitation_list.py
@@ -270,3 +270,88 @@ class RecitationsListTest(BaseTestCase):
         names = {item["name"] for item in items}
         self.assertIn("Silah Recitation", names)
         self.assertNotIn("Skoun Recitation", names)
+
+
+class RecitationBilingualSearchTest(BaseTestCase):
+    """Tests for Arabic + English bilingual search across recitations."""
+
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher, name="Publisher")
+        self.domain = baker.make(
+            "publishers.Domain",
+            domain="bilingual.com",
+            publisher=self.publisher,
+            is_primary=True,
+        )
+        self.user = User.objects.create_user(email="bilingual@example.com", name="Bilingual User")
+
+        self.qiraah = baker.make(Qiraah, name="Asim", name_ar="عاصم")
+        self.riwayah = baker.make(Riwayah, name="Hafs", name_ar="حفص عن عاصم", qiraah=self.qiraah)
+        self.reciter = baker.make(Reciter, name="Al-Husary", name_ar="الحصري", is_active=True)
+        resource = baker.make(
+            Resource,
+            publisher=self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.READY,
+        )
+        self.asset = baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=resource,
+            reciter=self.reciter,
+            riwayah=self.riwayah,
+            qiraah=self.qiraah,
+            name="Full Quran - Hafs",
+            name_ar="المصحف كامل - حفص",
+        )
+
+    def test_search_by_arabic_reciter_name(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=الحصري")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+        self.assertEqual(self.asset.id, items[0]["id"])
+
+    def test_search_by_english_reciter_name(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=Husary")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+        self.assertEqual(self.asset.id, items[0]["id"])
+
+    def test_search_by_arabic_riwayah_name(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=حفص")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+
+    def test_search_by_arabic_qiraah_name(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=عاصم")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+
+    def test_search_by_arabic_asset_name(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=المصحف")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+
+    def test_search_no_match_returns_empty(self):
+        self.authenticate_user(self.user, domain=self.domain)
+        response = self.client.get("/tenant/recitations/?search=nonexistent")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(0, len(items))


### PR DESCRIPTION
## Summary
- Expanded search fields on all recitation list endpoints to support bilingual (Arabic + English) search
- Added Arabic name variants (`name_ar`, `reciter__name_ar`, `riwayah__name_ar`, `qiraah__name_ar`) so users can search in either language regardless of active locale
- Extended riwayah and qiraah list search to include Arabic names for consistency

## Problem
The existing search only used `reciter__name` which resolves to the current language's translation field via `django-modeltranslation`. When the UI is in English, searching for "الحصري" (Arabic reciter name) returned no results because it only searched `reciter__name_en`.

## Before / After
| Search Term | Before | After |
|---|---|---|
| `الحصري` (Arabic reciter) | No results | Matches |
| `Al-Husary` (English reciter) | Matches | Matches |
| `حفص` (Arabic riwayah) | No results | Matches |
| `عاصم` (Arabic qiraah) | No results | Matches |
| `المصحف` (Arabic asset name) | No results | Matches |

## Files Changed
| File | Change |
|------|--------|
| `apps/content/api/tenant/recitation_list.py` | Added 6 Arabic search fields |
| `apps/content/api/internal/recitation_list.py` | Same |
| `apps/content/api/public/recitation_list.py` | Same |
| `apps/content/api/tenant/riwayah_list.py` | Added `name_ar` |
| `apps/content/api/tenant/qiraah_list.py` | Added `name_ar` |
| `apps/content/tests/tenant/test_recitation_list.py` | 6 new bilingual search tests |

## Existing Features (already worked, no changes needed)
- Filter by Riwayah ID (`riwayah_id` param) — already existed
- Filter by Qiraah ID (`qiraah_id` param) — already existed
- Server-side pagination (`@paginate`) — already existed
- Clearing filters resets results — handled by frontend

## Test Plan
- [ ] `test_search_by_arabic_reciter_name` — search "الحصري" finds recitation
- [ ] `test_search_by_english_reciter_name` — search "Husary" finds recitation
- [ ] `test_search_by_arabic_riwayah_name` — search "حفص" finds recitation
- [ ] `test_search_by_arabic_qiraah_name` — search "عاصم" finds recitation
- [ ] `test_search_by_arabic_asset_name` — search "المصحف" finds recitation
- [ ] `test_search_no_match_returns_empty` — search "nonexistent" returns empty

Closes #189