### PR TITLE
Enhance search and filter for recitations API

### DIFF
--- a/apps/content/api/tenant/recitation_list.py
+++ b/apps/content/api/tenant/recitation_list.py
@@ -40,12 +40,14 @@ class RecitationListOut(Schema):
     reciter: RecitationReciterOut
     riwayah: RecitationRiwayahOut | None = None
     qiraah: RecitationQiraahOut
+    surahs_count: int = Field(0, description="Number of surah tracks in this recitation")
 
 
 class RecitationFilter(FilterSchema):
     reciter_id: list[int] | None = Field(None, q="reciter_id__in")
     riwayah_id: list[int] | None = Field(None, q="riwayah_id__in")
     qiraah_id: list[int] | None = Field(None, q="qiraah_id__in")
+    publisher_id: list[int] | None = Field(None, q="resource__publisher_id__in")
     madd_level: list[Asset.MaddLevelChoice] | None = Field(None, q="madd_level__in")
     meem_behaviour: list[Asset.MeemBehaviorChoice] | None = Field(None, q="meem_behaviour__in")
 
@@ -53,12 +55,21 @@ class RecitationFilter(FilterSchema):
 @router.get("recitations/", response=list[RecitationListOut])
 @paginate
 @ordering(ordering_fields=["name", "created_at", "updated_at"])
-@searching(search_fields=["name", "description", "resource__publisher__name", "reciter__name"])
+@searching(
+    search_fields=[
+        "name",
+        "description",
+        "reciter__name",
+        "riwayah__name",
+        "qiraah__name",
+        "resource__publisher__name",
+    ]
+)
 def list_recitations(request: Request, filters: RecitationFilter = Query()):
     repo = RecitationRepository()
     service = RecitationService(repo)
 
     publisher_q = request.publisher_q("resource__publisher")
-    qs = service.get_all_recitations(publisher_q, filters)
+    qs = service.get_all_recitations(publisher_q, filters, annotate_surahs_count=True)
 
     return qs

--- a/apps/content/tests/tenant/test_recitation_list.py
+++ b/apps/content/tests/tenant/test_recitation_list.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
-from apps.content.models import Asset, RecitationSurahTrack, Reciter, Resource, Riwayah
+from apps.content.models import Asset, Qiraah, RecitationSurahTrack, Reciter, Resource, Riwayah
 from apps.core.tests import BaseTestCase
 from apps.publishers.models import Publisher
 from apps.users.models import User
@@ -270,3 +270,105 @@ class RecitationsListTest(BaseTestCase):
         names = {item["name"] for item in items}
         self.assertIn("Silah Recitation", names)
         self.assertNotIn("Skoun Recitation", names)
+
+    def test_list_recitations_search_by_riwayah_name(self):
+        self.authenticate_user(self.user, domain=self.domain1)
+
+        qiraah = baker.make(Qiraah, name="عاصم")
+        riwayah = baker.make(Riwayah, name="حفص عن عاصم", qiraah=qiraah)
+        baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=self.ready_recitation_resource_pub1,
+            reciter=self.reciter1,
+            riwayah=riwayah,
+            qiraah=qiraah,
+            name="Hafs Recitation",
+            description="Hafs",
+        )
+
+        response = self.client.get("/tenant/recitations/?search=حفص")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        names = {item["name"] for item in items}
+        self.assertIn("Hafs Recitation", names)
+
+    def test_list_recitations_search_by_qiraah_name(self):
+        self.authenticate_user(self.user, domain=self.domain1)
+
+        qiraah = baker.make(Qiraah, name="نافع")
+        riwayah = baker.make(Riwayah, name="ورش عن نافع", qiraah=qiraah)
+        baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=self.ready_recitation_resource_pub1,
+            reciter=self.reciter1,
+            riwayah=riwayah,
+            qiraah=qiraah,
+            name="Warsh Recitation",
+            description="Warsh",
+        )
+
+        response = self.client.get("/tenant/recitations/?search=نافع")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        names = {item["name"] for item in items}
+        self.assertIn("Warsh Recitation", names)
+
+    def test_list_recitations_filter_by_qiraah(self):
+        self.authenticate_user(self.user, domain=self.domain1)
+
+        qiraah = baker.make(Qiraah, name="Test Qiraah")
+        riwayah = baker.make(Riwayah, qiraah=qiraah)
+        baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=self.ready_recitation_resource_pub1,
+            reciter=self.reciter1,
+            riwayah=riwayah,
+            qiraah=qiraah,
+            name="Qiraah Filtered",
+        )
+
+        response = self.client.get(f"/tenant/recitations/?qiraah_id={qiraah.id}")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertTrue(all(item["qiraah"]["id"] == qiraah.id for item in items))
+
+    def test_list_recitations_includes_surahs_count(self):
+        self.authenticate_user(self.user, domain=self.domain1)
+
+        response = self.client.get("/tenant/recitations/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        for item in items:
+            self.assertIn("surahs_count", item)
+
+        asset1_item = next(i for i in items if i["id"] == self.asset1.id)
+        asset2_item = next(i for i in items if i["id"] == self.asset2.id)
+        self.assertEqual(2, asset1_item["surahs_count"])
+        self.assertEqual(1, asset2_item["surahs_count"])
+
+    def test_list_recitations_search_arabic_reciter_name(self):
+        self.authenticate_user(self.user, domain=self.domain1)
+
+        arabic_reciter = baker.make(Reciter, name="مشاري العفاسي")
+        baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            resource=self.ready_recitation_resource_pub1,
+            reciter=arabic_reciter,
+            riwayah=self.riwayah1,
+            name="Arabic Reciter Asset",
+        )
+
+        response = self.client.get("/tenant/recitations/?search=العفاسي")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+        self.assertEqual("Arabic Reciter Asset", items[0]["name"])


### PR DESCRIPTION
## Summary
Fixes #189

Enhances the existing `/tenant/recitations/` endpoint with improved search and filter capabilities for Arabic and English content.

### Changes

**Search Enhancements**
- Added `riwayah__name` and `qiraah__name` to search fields
- Arabic text search supported via Django's `icontains` (Unicode-aware)
- Users can search by Arabic riwayah names (e.g., "حفص عن عاصم") or qiraah names (e.g., "عاصم")

**New Filter**
- Added `publisher_id` filter to `RecitationFilter` schema

**Response Enhancement**
- Added `surahs_count` field showing number of surah tracks per recitation

**Tests Added**
- Search by Arabic riwayah name
- Search by Arabic qiraah name
- Search by Arabic reciter name
- Filter by qiraah_id
- Verify surahs_count in response

### Full Search Fields
`name`, `description`, `reciter__name`, `riwayah__name`, `qiraah__name`, `resource__publisher__name`

### Full Filter Fields
`reciter_id`, `riwayah_id`, `qiraah_id`, `publisher_id`, `madd_level`, `meem_behaviour`

## Test plan
- [ ] Search with Arabic reciter name returns matching results
- [ ] Search with Arabic riwayah name returns matching results
- [ ] Search with Arabic qiraah name returns matching results
- [ ] Filter by qiraah_id returns only matching recitations
- [ ] Response includes surahs_count with correct values
- [ ] Pagination continues to work correctly