### PR TITLE
fix: resolve /None in uploaded file paths

### DIFF
--- a/apps/core/test_uploads.py
+++ b/apps/core/test_uploads.py
@@ -1,0 +1,196 @@
+import re
+from types import SimpleNamespace
+from unittest import TestCase
+
+from apps.core.uploads import (
+    _require_fk,
+    _safe_pk,
+    upload_to_asset_files,
+    upload_to_asset_preview_images,
+    upload_to_asset_thumbnails,
+    upload_to_publisher_icons,
+    upload_to_recitation_surah_track_files,
+    upload_to_reciter_image,
+    upload_to_resource_files,
+)
+
+UUID_HEX_8 = re.compile(r"[0-9a-f]{8}")
+
+
+class RequireFkHelperTest(TestCase):
+    """Tests for the _require_fk validation helper"""
+
+    def test_raises_when_field_is_missing_from_instance(self):
+        instance = SimpleNamespace()
+        with self.assertRaisesRegex(ValueError, "TestModel.id is None"):
+            _require_fk(instance, "id", "TestModel", "Save first.")
+
+    def test_raises_when_field_is_none(self):
+        instance = SimpleNamespace(asset_id=None)
+        with self.assertRaisesRegex(ValueError, "TestModel.asset_id is None"):
+            _require_fk(instance, "asset_id", "TestModel", "Link first.")
+
+    def test_raises_when_field_is_empty_string(self):
+        instance = SimpleNamespace(asset_id="")
+        with self.assertRaisesRegex(ValueError, "TestModel.asset_id is None"):
+            _require_fk(instance, "asset_id", "TestModel", "Link first.")
+
+    def test_passes_when_field_has_valid_value(self):
+        instance = SimpleNamespace(id=42)
+        _require_fk(instance, "id", "TestModel", "Should not raise.")
+
+
+class SafePkHelperTest(TestCase):
+    """Tests for the _safe_pk UUID fallback helper"""
+
+    def test_returns_pk_as_string_when_set(self):
+        instance = SimpleNamespace(id=42)
+        self.assertEqual(_safe_pk(instance), "42")
+
+    def test_returns_uuid_hex_when_pk_is_none(self):
+        instance = SimpleNamespace(id=None)
+        result = _safe_pk(instance)
+        self.assertTrue(UUID_HEX_8.fullmatch(result), f"Expected 8-char hex, got: {result}")
+
+    def test_returns_uuid_hex_when_id_attr_missing(self):
+        instance = SimpleNamespace()
+        result = _safe_pk(instance)
+        self.assertTrue(UUID_HEX_8.fullmatch(result), f"Expected 8-char hex, got: {result}")
+
+
+class UploadToPublisherIconsTest(TestCase):
+    """Tests for upload_to_publisher_icons (Publisher.icon_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(id=5)
+        result = upload_to_publisher_icons(instance, "logo.PNG")
+        self.assertEqual(result, "uploads/publishers/5/icon.png")
+
+    def test_uses_uuid_fallback_when_pk_is_none(self):
+        instance = SimpleNamespace(id=None)
+        result = upload_to_publisher_icons(instance, "logo.png")
+        self.assertRegex(result, r"uploads/publishers/[0-9a-f]{8}/icon\.png")
+        self.assertNotIn("None", result)
+
+
+class UploadToAssetThumbnailsTest(TestCase):
+    """Tests for upload_to_asset_thumbnails (Asset.thumbnail_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(id=12)
+        result = upload_to_asset_thumbnails(instance, "cover.JPEG")
+        self.assertEqual(result, "uploads/assets/12/thumbnail.jpeg")
+
+    def test_uses_uuid_fallback_when_pk_is_none(self):
+        instance = SimpleNamespace(id=None)
+        result = upload_to_asset_thumbnails(instance, "cover.jpg")
+        self.assertRegex(result, r"uploads/assets/[0-9a-f]{8}/thumbnail\.jpg")
+        self.assertNotIn("None", result)
+
+
+class UploadToAssetPreviewImagesTest(TestCase):
+    """Tests for upload_to_asset_preview_images (AssetPreview.image_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(asset_id=10)
+        result = upload_to_asset_preview_images(instance, "preview shot.PNG")
+        self.assertEqual(result, "uploads/assets/10/preview/preview-shot.png")
+
+    def test_raises_when_asset_id_is_none(self):
+        instance = SimpleNamespace(asset_id=None)
+        with self.assertRaisesRegex(ValueError, "AssetPreview.asset_id is None"):
+            upload_to_asset_preview_images(instance, "image.jpg")
+
+    def test_raises_when_asset_id_is_empty_string(self):
+        instance = SimpleNamespace(asset_id="")
+        with self.assertRaisesRegex(ValueError, "AssetPreview.asset_id is None"):
+            upload_to_asset_preview_images(instance, "image.jpg")
+
+
+class UploadToAssetFilesTest(TestCase):
+    """Tests for upload_to_asset_files (AssetVersion.file_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(asset_id=42, id=7)
+        result = upload_to_asset_files(instance, "my document.PDF")
+        self.assertEqual(result, "uploads/assets/42/versions/7/my-document.pdf")
+
+    def test_raises_when_asset_id_is_none(self):
+        instance = SimpleNamespace(asset_id=None, id=7)
+        with self.assertRaisesRegex(ValueError, "AssetVersion.asset_id is None"):
+            upload_to_asset_files(instance, "file.pdf")
+
+    def test_raises_when_asset_id_is_empty_string(self):
+        instance = SimpleNamespace(asset_id="", id=7)
+        with self.assertRaisesRegex(ValueError, "AssetVersion.asset_id is None"):
+            upload_to_asset_files(instance, "file.pdf")
+
+    def test_uses_uuid_fallback_when_pk_is_none(self):
+        instance = SimpleNamespace(asset_id=42, id=None)
+        result = upload_to_asset_files(instance, "file.pdf")
+        self.assertRegex(result, r"uploads/assets/42/versions/[0-9a-f]{8}/file\.pdf")
+        self.assertNotIn("None", result)
+
+
+class UploadToResourceFilesTest(TestCase):
+    """Tests for upload_to_resource_files (ResourceVersion.storage_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(resource_id=3, id=15)
+        result = upload_to_resource_files(instance, "data file.json")
+        self.assertEqual(result, "uploads/resources/3/versions/15/data-file.json")
+
+    def test_raises_when_resource_id_is_none(self):
+        instance = SimpleNamespace(resource_id=None, id=15)
+        with self.assertRaisesRegex(ValueError, "ResourceVersion.resource_id is None"):
+            upload_to_resource_files(instance, "file.zip")
+
+    def test_raises_when_resource_id_is_empty_string(self):
+        instance = SimpleNamespace(resource_id="", id=15)
+        with self.assertRaisesRegex(ValueError, "ResourceVersion.resource_id is None"):
+            upload_to_resource_files(instance, "file.zip")
+
+    def test_uses_uuid_fallback_when_pk_is_none(self):
+        instance = SimpleNamespace(resource_id=3, id=None)
+        result = upload_to_resource_files(instance, "file.zip")
+        self.assertRegex(result, r"uploads/resources/3/versions/[0-9a-f]{8}/file\.zip")
+        self.assertNotIn("None", result)
+
+
+class UploadToRecitationSurahTrackFilesTest(TestCase):
+    """Tests for upload_to_recitation_surah_track_files (RecitationSurahTrack.audio_file)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(asset_id=5, surah_number=114)
+        result = upload_to_recitation_surah_track_files(instance, "audio.mp3")
+        self.assertEqual(result, "uploads/assets/5/recitations/114.mp3")
+
+    def test_pads_surah_number_to_three_digits(self):
+        instance = SimpleNamespace(asset_id=5, surah_number=1)
+        result = upload_to_recitation_surah_track_files(instance, "track.mp3")
+        self.assertEqual(result, "uploads/assets/5/recitations/001.mp3")
+
+    def test_raises_when_asset_id_is_none(self):
+        instance = SimpleNamespace(asset_id=None, surah_number=1)
+        with self.assertRaisesRegex(ValueError, "RecitationSurahTrack.asset_id is None"):
+            upload_to_recitation_surah_track_files(instance, "track.mp3")
+
+    def test_raises_when_surah_number_is_none(self):
+        instance = SimpleNamespace(asset_id=5, surah_number=None)
+        with self.assertRaisesRegex(ValueError, "surah_number is None"):
+            upload_to_recitation_surah_track_files(instance, "track.mp3")
+
+
+class UploadToReciterImageTest(TestCase):
+    """Tests for upload_to_reciter_image (Reciter.image_url)"""
+
+    def test_generates_correct_path(self):
+        instance = SimpleNamespace(id=8)
+        result = upload_to_reciter_image(instance, "photo.JPEG")
+        self.assertEqual(result, "uploads/reciters/8/icon.jpeg")
+
+    def test_uses_uuid_fallback_when_pk_is_none(self):
+        instance = SimpleNamespace(id=None)
+        result = upload_to_reciter_image(instance, "photo.jpg")
+        self.assertRegex(result, r"uploads/reciters/[0-9a-f]{8}/icon\.jpg")
+        self.assertNotIn("None", result)

--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import TYPE_CHECKING
 
 from django.utils.text import slugify
@@ -14,6 +15,21 @@ if TYPE_CHECKING:
     from apps.publishers.models import Publisher
 
 
+def _require_fk(instance: object, field: str, model_name: str, message: str) -> None:
+    """Validate that a required foreign key field is not None or empty before generating an upload path."""
+    value = getattr(instance, field, None)
+    if value is None or value == "":
+        raise ValueError(f"Cannot generate upload path: {model_name}.{field} is None. {message}")
+
+
+def _safe_pk(instance: object) -> str:
+    """Return the instance PK, or a UUID fallback for unsaved objects with AutoField PKs."""
+    pk = getattr(instance, "id", None)
+    if pk is None:
+        return uuid.uuid4().hex[:8]
+    return str(pk)
+
+
 def upload_to_publisher_icons(instance: "Publisher", filename: str) -> str:
     """
     Generate upload path for publisher icon images
@@ -21,7 +37,7 @@ def upload_to_publisher_icons(instance: "Publisher", filename: str) -> str:
     """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/publishers/{instance.id}/{filename}"
+    return f"uploads/publishers/{_safe_pk(instance)}/{filename}"
 
 
 def upload_to_asset_thumbnails(instance: "Asset", filename: str) -> str:
@@ -31,7 +47,7 @@ def upload_to_asset_thumbnails(instance: "Asset", filename: str) -> str:
     """
     ext = filename.split(".")[-1].lower()
     filename = f"thumbnail.{ext}"
-    return f"uploads/assets/{instance.id}/{filename}"
+    return f"uploads/assets/{_safe_pk(instance)}/{filename}"
 
 
 def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> str:
@@ -39,6 +55,7 @@ def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> s
     Generate upload path for asset preview images
     Format: uploads/assets/{asset_id}/preview/{filename}
     """
+    _require_fk(instance, "asset_id", "AssetPreview", "Link it to an Asset before uploading files.")
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
     return f"uploads/assets/{instance.asset_id}/preview/{safe_filename}"
 
@@ -46,21 +63,23 @@ def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> s
 def upload_to_asset_files(instance: "AssetVersion", filename: str) -> str:
     """
     Generate upload path for asset version files
-    Format: uploads/assets/{asset_id}/versions/{asset_version_id}/{filename}
+    Format: uploads/assets/{asset_id}/versions/{version_id}/{filename}
     """
+    _require_fk(instance, "asset_id", "AssetVersion", "Link it to an Asset before uploading files.")
     # Keep original filename for downloadable assets
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/assets/{instance.asset_id}/versions/{instance.id}/{safe_filename}"
+    return f"uploads/assets/{instance.asset_id}/versions/{_safe_pk(instance)}/{safe_filename}"
 
 
 def upload_to_resource_files(instance: "ResourceVersion", filename: str) -> str:
     """
     Generate upload path for resource version files
-    Format: uploads/resources/{resource_id}/versions/{resource_version_id}/{filename}
+    Format: uploads/resources/{resource_id}/versions/{version_id}/{filename}
     """
+    _require_fk(instance, "resource_id", "ResourceVersion", "Link it to a Resource before uploading files.")
     # Keep original filename for downloadable resources
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/resources/{instance.resource_id}/versions/{instance.id}/{safe_filename}"
+    return f"uploads/resources/{instance.resource_id}/versions/{_safe_pk(instance)}/{safe_filename}"
 
 
 def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", filename: str) -> str:
@@ -68,15 +87,18 @@ def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", fil
     Generate upload path for recitation surah track audio files.
     Format: uploads/assets/{asset_id}/recitations/{surah_number:03}.{ext}
     """
+    _require_fk(instance, "asset_id", "RecitationSurahTrack", "Link it to an Asset before uploading files.")
+    if instance.surah_number is None:
+        raise ValueError("Cannot generate upload path: RecitationSurahTrack.surah_number is None.")
     ext = filename.split(".")[-1].lower() if "." in filename else "mp3"
     return f"uploads/assets/{instance.asset_id}/recitations/{int(instance.surah_number):03}.{ext}"
 
 
 def upload_to_reciter_image(instance: "Reciter", filename: str) -> str:
     """
-    Generate upload path for publisher icon images
-    Format: uploads/reciters/{reciter_id}/image.{ext}
+    Generate upload path for reciter images
+    Format: uploads/reciters/{reciter_id}/icon.{ext}
     """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/reciters/{instance.id}/{filename}"
+    return f"uploads/reciters/{_safe_pk(instance)}/{filename}"


### PR DESCRIPTION
## Summary

- Fixes the `/None` issue in uploaded file paths for `AssetVersion`, `AssetPreview`, `RecitationSurahTrack`, `ResourceVersion`, and other models
- Adds `_require_fk()` helper that validates foreign keys (`asset_id`, `resource_id`) are set before generating upload paths — raises `ValueError` with a clear, actionable message
- Adds `_safe_pk()` helper that uses a UUID fallback for unsaved objects with `AutoField` PKs (since Django calls `upload_to` before the PK is assigned during `objects.create()`)
- Guards all 7 `upload_to` functions in `apps/core/uploads.py`
- Adds `surah_number` None check for `RecitationSurahTrack`
- Fixes incorrect docstring in `upload_to_reciter_image`

## Root Cause

When `upload_to` callbacks reference `instance.asset_id` (FK) or `instance.id` (PK), and these values are `None`, Python's f-string interpolation silently produces paths like `uploads/assets/None/versions/None/file.pdf`. This creates corrupted file paths in storage.

**FK fields** (`asset_id`, `resource_id`): Now raise `ValueError` — these must always be set before file upload.

**PK fields** (`instance.id`): Now use a UUID fallback — Django's `AutoField` PK is naturally `None` when `upload_to` runs during the first `save()`, so a UUID ensures uniqueness without breaking `objects.create()` patterns.

## Test plan

- [x] 28 new unit tests covering all 7 upload functions (happy path + None validation)
- [x] All 194 tests pass in Docker (166 existing + 28 new, 0 failures)
- [x] Ruff lint clean
- [x] Regression verified: `/None/` never appears in generated paths
- [x] Existing download/upload tests unaffected (previously broke with strict PK check)

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for upload utilities, including validation of file path generation, UUID fallbacks, and error handling.

* **Chores**
  * Improved internal upload path generation with enhanced validation for file relationships and more robust identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->