### PR TITLE
feat: add sorted reciters listing endpoint with detailed fields and d…

### DIFF
--- a/apps/content/api/internal/list_reciters.py
+++ b/apps/content/api/internal/list_reciters.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from ninja import Schema
 from ninja.pagination import paginate
 from pydantic import AwareDatetime

--- a/apps/content/tests/internal/test_reciter_list.py
+++ b/apps/content/tests/internal/test_reciter_list.py
@@ -42,7 +42,7 @@ class RecitersListTest(BaseTestCase):
         )
         return reciter
 
-    def test_list_reciters_returns_only_active_reciters_with_ready_recitations(self):
+    def test_reciters_listing_where_having_multiple_reciters_api_should_return_only_active_reciters_with_ready_recitations(self):
         self._make_reciter_with_recitation(Resource.StatusChoice.READY, name_ar="قارئ نشط", is_active=True)             # Active + READY → appears
         self._make_reciter_with_recitation(Resource.StatusChoice.READY, name_ar="قارئ غير نشط ١", is_active=False)      # Inactive + READY → does NOT appear
         self._make_reciter_with_recitation(Resource.StatusChoice.DRAFT, name_ar="قارئ غير نشط ٢", is_active=False)      # Inactive + DRAFT → does NOT appear
@@ -77,7 +77,7 @@ class RecitersListTest(BaseTestCase):
         self.assertIn("created_at", item)
         self.assertIn("updated_at", item)
 
-    def test_list_reciters_default_ordering_by_name_ar(self):
+    def test_reciters_where_no_ordering_parameter_provided_api_should_fallback_to_ordering_by_name_ar(self):
         for name_ar in ["ياسر الدوسري", "أحمد العجمي", "سعد الغامدي"]:
             self._make_reciter_with_recitation(name_ar=name_ar, is_active=True)
 
@@ -91,7 +91,7 @@ class RecitersListTest(BaseTestCase):
         self.assertEqual(sorted(names), names)
 
 
-    def test_list_reciters_search_by_name_ar(self):
+    def test_reciters_listing_where_search_paramter_is_provided_api_should_return_matched_reciters(self):
         self._make_reciter_with_recitation(
             name="Mishary Rashid", name_ar="مشاري راشد العفاسي", is_active=True
         )


### PR DESCRIPTION
add sorted reciters listing endpoint with detailed fields and default ordering and create test code

this change resolves #195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reciters list API with pagination, sorting, and search.
  * Search filters by reciter name (Arabic/English) and slug.
  * Returns detailed reciter info: name, bio, slug, active status, profile image, created_at, updated_at.
  * Only reciters with ready recitations are shown; default sorting is by Arabic name.

* **Tests**
  * Expanded tests covering listing, search, ordering, and returned fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->