### PR TITLE
feat: add default sorting and additional fields to reciters

### DIFF
--- a/apps/content/api/internal/reciter_list.py
+++ b/apps/content/api/internal/reciter_list.py
@@ -1,3 +1,4 @@
+from django.db.models import F
 from ninja import FilterSchema, Query, Schema
 from ninja.pagination import paginate
 from pydantic import AwareDatetime, Field
@@ -33,8 +34,8 @@ class ReciterFilter(FilterSchema):
 
 @router.get("reciters/", response=list[ReciterOut])
 @paginate
-@ordering(ordering_fields=["name_ar", "name_en", "created_at", "updated_at"])
-@searching(search_fields=["name_en", "name_ar", "slug"])
+@ordering(ordering_fields=["name", "name_ar", "name_en", "created_at", "updated_at"])
+@searching(search_fields=["name", "name_en", "name_ar", "slug"])
 def list_reciters(request: Request, filters: ReciterFilter = Query()):
     """
     Tenant Content API:
@@ -54,4 +55,4 @@ def list_reciters(request: Request, filters: ReciterFilter = Query()):
     publisher_q = request.publisher_q("assets__resource__publisher")
     qs = service.get_all_reciters(publisher_q, filters)
 
-    return qs.order_by("name_ar")
+    return qs.order_by(F("name_ar").asc(nulls_last=True))

--- a/apps/content/api/internal/reciter_list.py
+++ b/apps/content/api/internal/reciter_list.py
@@ -1,6 +1,6 @@
 from ninja import FilterSchema, Query, Schema
 from ninja.pagination import paginate
-from pydantic import Field
+from pydantic import AwareDatetime, Field
 
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
@@ -9,6 +9,7 @@ from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
 from apps.core.ninja_utils.searching_base import searching
 from apps.core.ninja_utils.tags import NinjaTag
+from apps.core.ninja_utils.types import AbsoluteUrl
 
 router = ItqanRouter(tags=[NinjaTag.RECITERS])
 
@@ -16,8 +17,12 @@ router = ItqanRouter(tags=[NinjaTag.RECITERS])
 class ReciterOut(Schema):
     id: int
     name: str
+    slug: str
     bio: str
     recitations_count: int = Field(0, description="Number of READY recitation assets for this reciter")
+    image_url: AbsoluteUrl | None
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
 
 
 class ReciterFilter(FilterSchema):
@@ -28,8 +33,8 @@ class ReciterFilter(FilterSchema):
 
 @router.get("reciters/", response=list[ReciterOut])
 @paginate
-@ordering(ordering_fields=["name"])
-@searching(search_fields=["name", "name_ar", "slug"])
+@ordering(ordering_fields=["name_ar", "name_en", "created_at", "updated_at"])
+@searching(search_fields=["name_en", "name_ar", "slug"])
 def list_reciters(request: Request, filters: ReciterFilter = Query()):
     """
     Tenant Content API:
@@ -49,4 +54,4 @@ def list_reciters(request: Request, filters: ReciterFilter = Query()):
     publisher_q = request.publisher_q("assets__resource__publisher")
     qs = service.get_all_reciters(publisher_q, filters)
 
-    return qs
+    return qs.order_by("name_ar")

--- a/apps/content/tests/internal/test_reciter_list.py
+++ b/apps/content/tests/internal/test_reciter_list.py
@@ -85,6 +85,37 @@ class RecitersListTest(BaseTestCase):
             authorization_grant_type="password",
         )
 
+        self.recitation_resource = baker.make(
+            Resource,
+            publisher=self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.READY,
+        )
+        self.draft_recitation_resource = baker.make(
+            Resource,
+            publisher=self.publisher,
+            category=Resource.CategoryChoice.RECITATION,
+            status=Resource.StatusChoice.DRAFT,
+        )
+        self.riwayah = baker.make("content.Riwayah")
+
+    def _make_reciter_with_recitation(self, resource_status=Resource.StatusChoice.READY, **kwargs):
+        """Create a reciter with a recitation asset linked to a resource of the given status."""
+        resource = (
+            self.recitation_resource
+            if resource_status == Resource.StatusChoice.READY
+            else self.draft_recitation_resource
+        )
+        reciter = baker.make(Reciter, **kwargs)
+        baker.make(
+            Asset,
+            category=Resource.CategoryChoice.RECITATION,
+            reciter=reciter,
+            resource=resource,
+            riwayah=self.riwayah,
+        )
+        return reciter
+
     def test_list_reciters_should_return_only_active_reciters_with_ready_recitations(self):
         # Arrange
         self.authenticate_client(self.app)
@@ -113,7 +144,7 @@ class RecitersListTest(BaseTestCase):
         # Only the valid RECITATION asset with READY + RECITATION resource should be counted
         self.assertEqual(1, reciter_item["recitations_count"])
 
-    def test_list_reciters_ordering_by_name(self):
+    def test_list_reciters_ordering_by_name_en(self):
         # Arrange – another active reciter so we can test ordering
         other_reciter = baker.make(Reciter, is_active=True, name="A Reciter")
         baker.make(
@@ -126,7 +157,7 @@ class RecitersListTest(BaseTestCase):
         self.authenticate_client(self.app)
 
         # Act
-        response = self.client.get("/reciters/?ordering=name")
+        response = self.client.get("/reciters/?ordering=name_en")
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
@@ -134,3 +165,28 @@ class RecitersListTest(BaseTestCase):
 
         names = [item["name"] for item in items]
         self.assertEqual(sorted(names), names)  # ascending by name
+
+    def test_reciters_where_no_ordering_parameter_provided_api_should_fallback_to_ordering_by_name_ar(self):
+        for name_ar in ["ياسر الدوسري", "أحمد العجمي", "سعد الغامدي"]:
+            self._make_reciter_with_recitation(name_ar=name_ar, is_active=True)
+
+        # Use Accept-Language: ar so that `name` in the response maps to name_ar
+        self.authenticate_user(self.user, language="ar")
+        response = self.client.get("/cms-api/reciters/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        names = [item["name"] for item in items]
+        self.assertEqual(sorted(names), names)
+
+    def test_reciters_listing_where_search_paramter_is_provided_api_should_return_matched_reciters(self):
+        self._make_reciter_with_recitation(name="Mishary Rashid", name_ar="مشاري راشد العفاسي", is_active=True)
+        self._make_reciter_with_recitation(name="Saad Al-Ghamidi", name_ar="سعد الغامدي", is_active=True)
+        self.authenticate_user(self.user, language="ar")
+
+        response = self.client.get("/cms-api/reciters/", data={"search": "مشاري"})
+
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("مشاري راشد العفاسي", body["results"][0]["name"])


### PR DESCRIPTION
## Summary

Enhances the internal reciter list API to expose richer reciter details and establish a stable, Arabic-first default ordering.

## What changed and why

### Richer `ReciterOut` schema
Added `slug`, `image_url`, `created_at`, and `updated_at` to the response payload.

### Default ordering by `name_ar`
Changed the default sort to `name_ar` so that when no `?ordering=` param is provided, the list is returned in a consistent, Arabic-alphabetical order. Null-safe ordering is applied via `qs.order_by(F("name_ar").asc(nulls_last=True))` to ensure reciters without an Arabic name are pushed to the bottom rather than surfacing unpredictably at the top.

### Backwards-compatible ordering fields
Preserved the old `name` field in `@ordering` alongside the new `name_en`, `name_ar`, `created_at`, and `updated_at` to avoid breaking any existing clients using `?ordering=name`.

### Backwards-compatible search fields
Preserved the old `name` field in `@searching` alongside `name_en`, `name_ar`, and `slug` to avoid breaking any existing clients using `?search=` against the old field name.

## Tests
- Added `test_reciters_where_no_ordering_parameter_provided_api_should_fallback_to_ordering_by_name_ar` — verifies the Arabic-first default sort is applied when no ordering param is passed
- Added `test_reciters_listing_where_search_paramter_is_provided_api_should_return_matched_reciters` — covers Arabic name search returning the correct matched reciter
- Added `_make_reciter_with_recitation` private helper to reduce test setup boilerplate when creating reciters with linked recitation assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reciter data now includes slug, image URL, and creation/update timestamps
  * Search functionality expanded to filter by name variations and slug identifiers
  * Additional sorting options available including creation and update date ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->