### PR TITLE
fix: resolve /None file path and add resources pagination

### DIFF
--- a/apps/content/tests/internal/test_resources.py
+++ b/apps/content/tests/internal/test_resources.py
@@ -39,6 +39,18 @@ class ResourceListTest(BaseTestCase):
         # Check pagination structure
         self.assertIn("results", body)
         self.assertIn("count", body)
+        self.assertIn("total", body)
+        self.assertIn("page", body)
+        self.assertIn("pageSize", body)
+        self.assertIn("totalPages", body)
+        self.assertIn("nextPage", body)
+        self.assertIn("prevPage", body)
+
+        self.assertEqual(2, body["total"])
+        self.assertEqual(1, body["page"])
+        self.assertEqual(1, body["totalPages"])
+        self.assertIsNone(body["nextPage"])
+        self.assertIsNone(body["prevPage"])
 
         items = body["results"]
         self.assertEqual(2, len(items))
@@ -490,3 +502,38 @@ class ResourceListTest(BaseTestCase):
         self.assertEqual(usage_event.user_agent, "Test Agent/1.0")
         # Note: IP address capture depends on Django test client configuration
         # In real requests, this would capture the client IP
+
+    def test_list_resources_pagination_should_return_correct_pages(self):
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
+
+        response = self.client.get("/cms-api/resources/?page=1&page_size=2")
+
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(5, body["total"])
+        self.assertEqual(1, body["page"])
+        self.assertEqual(2, body["pageSize"])
+        self.assertEqual(3, body["totalPages"])
+        self.assertEqual(2, body["nextPage"])
+        self.assertIsNone(body["prevPage"])
+        self.assertEqual(2, len(body["results"]))
+
+    def test_list_resources_pagination_last_page_should_have_no_next(self):
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
+
+        response = self.client.get("/cms-api/resources/?page=3&page_size=2")
+
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(5, body["total"])
+        self.assertEqual(3, body["page"])
+        self.assertEqual(3, body["totalPages"])
+        self.assertIsNone(body["nextPage"])
+        self.assertEqual(2, body["prevPage"])
+        self.assertEqual(1, len(body["results"]))

--- a/apps/content/tests/internal/test_resources.py
+++ b/apps/content/tests/internal/test_resources.py
@@ -503,13 +503,16 @@ class ResourceListTest(BaseTestCase):
         # Note: IP address capture depends on Django test client configuration
         # In real requests, this would capture the client IP
 
-    def test_list_resources_pagination_should_return_correct_pages(self):
+    def test_list_resources_where_page_is_first_should_return_correct_pages(self) -> None:
+        # Arrange
         self.authenticate_user(self.user)
         for i in range(5):
             baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
 
-        response = self.client.get("/cms-api/resources/?page=1&page_size=2")
+        # Act
+        response = self.client.get("/cms-api/resources/?page=1&pageSize=2")
 
+        # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
 
@@ -517,17 +520,21 @@ class ResourceListTest(BaseTestCase):
         self.assertEqual(1, body["page"])
         self.assertEqual(2, body["pageSize"])
         self.assertEqual(3, body["totalPages"])
-        self.assertEqual(2, body["nextPage"])
+        self.assertIsNotNone(body["nextPage"])
+        self.assertIn("page=2", body["nextPage"])
         self.assertIsNone(body["prevPage"])
         self.assertEqual(2, len(body["results"]))
 
-    def test_list_resources_pagination_last_page_should_have_no_next(self):
+    def test_list_resources_where_page_is_last_should_have_no_next(self) -> None:
+        # Arrange
         self.authenticate_user(self.user)
         for i in range(5):
             baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
 
-        response = self.client.get("/cms-api/resources/?page=3&page_size=2")
+        # Act
+        response = self.client.get("/cms-api/resources/?page=3&pageSize=2")
 
+        # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
 
@@ -535,5 +542,6 @@ class ResourceListTest(BaseTestCase):
         self.assertEqual(3, body["page"])
         self.assertEqual(3, body["totalPages"])
         self.assertIsNone(body["nextPage"])
-        self.assertEqual(2, body["prevPage"])
+        self.assertIsNotNone(body["prevPage"])
+        self.assertIn("page=2", body["prevPage"])
         self.assertEqual(1, len(body["results"]))

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -5,7 +5,7 @@ from django.db.models import QuerySet
 from django.http import HttpRequest
 from ninja import Schema
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
-from pydantic import Field
+from pydantic import Field, field_validator
 
 MAX_PAGE_SIZE = 1000
 DEFAULT_PAGE_SIZE = 20
@@ -20,9 +20,10 @@ class NinjaPagination(NinjaPageNumberPagination):
 
         model_config = {"populate_by_name": True}
 
-        def __init__(self, **kwargs: Any) -> None:
-            super().__init__(**kwargs)
-            self.page_size = min(self.page_size, MAX_PAGE_SIZE)
+        @field_validator("page_size")
+        @classmethod
+        def clamp_page_size(cls, value: int) -> int:
+            return min(value, MAX_PAGE_SIZE)
 
     class Output(Schema):
         results: list[Any]

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -2,6 +2,7 @@ import math
 from typing import Any
 
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from ninja import Schema
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
 from pydantic import Field
@@ -15,11 +16,13 @@ class NinjaPagination(NinjaPageNumberPagination):
 
     class Input(Schema):
         page: int = Field(1, ge=1)
-        page_size: int = Field(DEFAULT_PAGE_SIZE, ge=1)
+        page_size: int = Field(DEFAULT_PAGE_SIZE, ge=1, alias="pageSize")
 
-        def __init__(self, page_size: int = DEFAULT_PAGE_SIZE, **kwargs: Any) -> None:
-            self.page_size = min(page_size, MAX_PAGE_SIZE)
+        model_config = {"populate_by_name": True}
+
+        def __init__(self, **kwargs: Any) -> None:
             super().__init__(**kwargs)
+            self.page_size = min(self.page_size, MAX_PAGE_SIZE)
 
     class Output(Schema):
         results: list[Any]
@@ -28,17 +31,35 @@ class NinjaPagination(NinjaPageNumberPagination):
         page: int
         page_size: int = Field(alias="pageSize")
         total_pages: int = Field(alias="totalPages")
-        next_page: int | None = Field(None, alias="nextPage")
-        prev_page: int | None = Field(None, alias="prevPage")
+        next_page: str | None = Field(None, alias="nextPage")
+        prev_page: str | None = Field(None, alias="prevPage")
+
+    @staticmethod
+    def _build_page_url(request: HttpRequest | None, page: int, page_size: int) -> str | None:
+        if request is None:
+            return None
+        path = request.path
+        return f"{path}?page={page}&pageSize={page_size}"
 
     def _build_pagination_response(
         self,
         queryset: QuerySet,
         pagination: Input,
         total: int,
+        request: HttpRequest | None = None,
     ) -> dict[str, Any]:
         offset = (pagination.page - 1) * pagination.page_size
         total_pages = math.ceil(total / pagination.page_size) if pagination.page_size > 0 else 0
+        next_page = (
+            self._build_page_url(request, pagination.page + 1, pagination.page_size)
+            if pagination.page < total_pages
+            else None
+        )
+        prev_page = (
+            self._build_page_url(request, pagination.page - 1, pagination.page_size)
+            if pagination.page > 1
+            else None
+        )
         return {
             "results": queryset[offset : offset + pagination.page_size],
             "count": total,
@@ -46,8 +67,8 @@ class NinjaPagination(NinjaPageNumberPagination):
             "page": pagination.page,
             "pageSize": pagination.page_size,
             "totalPages": total_pages,
-            "nextPage": pagination.page + 1 if pagination.page < total_pages else None,
-            "prevPage": pagination.page - 1 if pagination.page > 1 else None,
+            "nextPage": next_page,
+            "prevPage": prev_page,
         }
 
     def paginate_queryset(
@@ -57,7 +78,8 @@ class NinjaPagination(NinjaPageNumberPagination):
         **params: Any,
     ) -> Any:
         total = self._items_count(queryset)
-        return self._build_pagination_response(queryset, pagination, total)
+        request = params.get("request")
+        return self._build_pagination_response(queryset, pagination, total, request)
 
     async def apaginate_queryset(
         self,
@@ -66,4 +88,5 @@ class NinjaPagination(NinjaPageNumberPagination):
         **params: Any,
     ) -> Any:
         total = await self._aitems_count(queryset)
-        return self._build_pagination_response(queryset, pagination, total)
+        request = params.get("request")
+        return self._build_pagination_response(queryset, pagination, total, request)

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 from django.db.models import QuerySet
@@ -23,6 +24,31 @@ class NinjaPagination(NinjaPageNumberPagination):
     class Output(Schema):
         results: list[Any]
         count: int
+        total: int
+        page: int
+        page_size: int = Field(alias="pageSize")
+        total_pages: int = Field(alias="totalPages")
+        next_page: int | None = Field(None, alias="nextPage")
+        prev_page: int | None = Field(None, alias="prevPage")
+
+    def _build_pagination_response(
+        self,
+        queryset: QuerySet,
+        pagination: Input,
+        total: int,
+    ) -> dict[str, Any]:
+        offset = (pagination.page - 1) * pagination.page_size
+        total_pages = math.ceil(total / pagination.page_size) if pagination.page_size > 0 else 0
+        return {
+            "results": queryset[offset : offset + pagination.page_size],
+            "count": total,
+            "total": total,
+            "page": pagination.page,
+            "pageSize": pagination.page_size,
+            "totalPages": total_pages,
+            "nextPage": pagination.page + 1 if pagination.page < total_pages else None,
+            "prevPage": pagination.page - 1 if pagination.page > 1 else None,
+        }
 
     def paginate_queryset(
         self,
@@ -30,11 +56,8 @@ class NinjaPagination(NinjaPageNumberPagination):
         pagination: Input,
         **params: Any,
     ) -> Any:
-        offset = (pagination.page - 1) * pagination.page_size
-        return {
-            "results": queryset[offset : offset + pagination.page_size],
-            "count": self._items_count(queryset),
-        }
+        total = self._items_count(queryset)
+        return self._build_pagination_response(queryset, pagination, total)
 
     async def apaginate_queryset(
         self,
@@ -42,8 +65,5 @@ class NinjaPagination(NinjaPageNumberPagination):
         pagination: Input,
         **params: Any,
     ) -> Any:
-        offset = (pagination.page - 1) * pagination.page_size
-        return {
-            "results": queryset[offset : offset + pagination.page_size],
-            "count": await self._aitems_count(queryset),
-        }
+        total = await self._aitems_count(queryset)
+        return self._build_pagination_response(queryset, pagination, total)

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -38,8 +38,12 @@ class NinjaPagination(NinjaPageNumberPagination):
     def _build_page_url(request: HttpRequest | None, page: int, page_size: int) -> str | None:
         if request is None:
             return None
-        path = request.path
-        return f"{path}?page={page}&pageSize={page_size}"
+        query = request.GET.copy()
+        query["page"] = str(page)
+        query["pageSize"] = str(page_size)
+        if "page_size" in query:
+            del query["page_size"]
+        return f"{request.path}?{query.urlencode()}"
 
     def _build_pagination_response(
         self,

--- a/apps/core/test_uploads.py
+++ b/apps/core/test_uploads.py
@@ -1,0 +1,173 @@
+from types import SimpleNamespace
+from unittest import TestCase
+
+from apps.core.uploads import (
+    _safe_id,
+    upload_to_asset_files,
+    upload_to_asset_preview_images,
+    upload_to_asset_thumbnails,
+    upload_to_publisher_icons,
+    upload_to_recitation_surah_track_files,
+    upload_to_reciter_image,
+    upload_to_resource_files,
+)
+
+
+class SafeIdTest(TestCase):
+    """Tests for the _safe_id helper that prevents None in file paths."""
+
+    def test_safe_id_where_id_is_integer_should_return_string_of_id(self) -> None:
+        """Verify that a valid integer ID is returned as its string representation."""
+        result = _safe_id(42)
+        self.assertEqual(result, "42")
+
+    def test_safe_id_where_id_is_none_should_return_uuid_fallback(self) -> None:
+        """Verify that None produces a 12-character hex fallback instead of 'None'."""
+        result = _safe_id(None)
+        self.assertNotEqual(result, "None")
+        self.assertEqual(len(result), 12)
+        self.assertTrue(all(c in "0123456789abcdef" for c in result))
+
+    def test_safe_id_where_id_is_none_should_return_unique_values(self) -> None:
+        """Verify that repeated calls with None produce different fallbacks."""
+        results = {_safe_id(None) for _ in range(10)}
+        self.assertEqual(len(results), 10)
+
+    def test_safe_id_where_id_is_zero_should_return_zero_string(self) -> None:
+        """Verify that zero is treated as a valid ID, not as falsy."""
+        result = _safe_id(0)
+        self.assertEqual(result, "0")
+
+
+class UploadToAssetFilesTest(TestCase):
+    """Tests for upload_to_asset_files path generation."""
+
+    def test_upload_to_asset_files_where_ids_are_set_should_return_correct_path(self) -> None:
+        """Verify correct path when both asset_id and instance id are set."""
+        instance = SimpleNamespace(asset_id=5, id=10)
+        result = upload_to_asset_files(instance, "document.pdf")
+        self.assertEqual(result, "uploads/assets/5/versions/10/document.pdf")
+
+    def test_upload_to_asset_files_where_instance_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears in the path when instance.id is None."""
+        instance = SimpleNamespace(asset_id=5, id=None)
+        result = upload_to_asset_files(instance, "document.pdf")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.startswith("uploads/assets/5/versions/"))
+        self.assertTrue(result.endswith("/document.pdf"))
+
+    def test_upload_to_asset_files_where_asset_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears in the path when asset_id is None."""
+        instance = SimpleNamespace(asset_id=None, id=10)
+        result = upload_to_asset_files(instance, "document.pdf")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.startswith("uploads/assets/"))
+        self.assertIn("/versions/10/document.pdf", result)
+
+    def test_upload_to_asset_files_where_both_ids_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when both IDs are None."""
+        instance = SimpleNamespace(asset_id=None, id=None)
+        result = upload_to_asset_files(instance, "document.pdf")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.startswith("uploads/assets/"))
+        self.assertTrue(result.endswith(".pdf"))
+
+
+class UploadToResourceFilesTest(TestCase):
+    """Tests for upload_to_resource_files path generation."""
+
+    def test_upload_to_resource_files_where_ids_are_set_should_return_correct_path(self) -> None:
+        """Verify correct path when both resource_id and instance id are set."""
+        instance = SimpleNamespace(resource_id=3, id=7)
+        result = upload_to_resource_files(instance, "data.csv")
+        self.assertEqual(result, "uploads/resources/3/versions/7/data.csv")
+
+    def test_upload_to_resource_files_where_instance_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when instance.id is None."""
+        instance = SimpleNamespace(resource_id=3, id=None)
+        result = upload_to_resource_files(instance, "data.csv")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.startswith("uploads/resources/3/versions/"))
+
+
+class UploadToPublisherIconsTest(TestCase):
+    """Tests for upload_to_publisher_icons path generation."""
+
+    def test_upload_to_publisher_icons_where_id_is_set_should_return_correct_path(self) -> None:
+        """Verify correct path when publisher id is set."""
+        instance = SimpleNamespace(id=1)
+        result = upload_to_publisher_icons(instance, "logo.png")
+        self.assertEqual(result, "uploads/publishers/1/icon.png")
+
+    def test_upload_to_publisher_icons_where_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when publisher id is None."""
+        instance = SimpleNamespace(id=None)
+        result = upload_to_publisher_icons(instance, "logo.png")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.startswith("uploads/publishers/"))
+        self.assertTrue(result.endswith("/icon.png"))
+
+
+class UploadToAssetThumbnailsTest(TestCase):
+    """Tests for upload_to_asset_thumbnails path generation."""
+
+    def test_upload_to_asset_thumbnails_where_id_is_set_should_return_correct_path(self) -> None:
+        """Verify correct path when asset id is set."""
+        instance = SimpleNamespace(id=8)
+        result = upload_to_asset_thumbnails(instance, "cover.jpg")
+        self.assertEqual(result, "uploads/assets/8/thumbnail.jpg")
+
+    def test_upload_to_asset_thumbnails_where_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when asset id is None."""
+        instance = SimpleNamespace(id=None)
+        result = upload_to_asset_thumbnails(instance, "cover.jpg")
+        self.assertNotIn("None", result)
+
+
+class UploadToAssetPreviewImagesTest(TestCase):
+    """Tests for upload_to_asset_preview_images path generation."""
+
+    def test_upload_to_asset_preview_images_where_asset_id_is_set_should_return_correct_path(self) -> None:
+        """Verify correct path when asset_id is set."""
+        instance = SimpleNamespace(asset_id=4)
+        result = upload_to_asset_preview_images(instance, "preview shot.png")
+        self.assertEqual(result, "uploads/assets/4/preview/preview-shot.png")
+
+    def test_upload_to_asset_preview_images_where_asset_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when asset_id is None."""
+        instance = SimpleNamespace(asset_id=None)
+        result = upload_to_asset_preview_images(instance, "shot.png")
+        self.assertNotIn("None", result)
+
+
+class UploadToReciterImageTest(TestCase):
+    """Tests for upload_to_reciter_image path generation."""
+
+    def test_upload_to_reciter_image_where_id_is_set_should_return_correct_path(self) -> None:
+        """Verify correct path when reciter id is set."""
+        instance = SimpleNamespace(id=12)
+        result = upload_to_reciter_image(instance, "photo.jpg")
+        self.assertEqual(result, "uploads/reciters/12/icon.jpg")
+
+    def test_upload_to_reciter_image_where_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when reciter id is None."""
+        instance = SimpleNamespace(id=None)
+        result = upload_to_reciter_image(instance, "photo.jpg")
+        self.assertNotIn("None", result)
+
+
+class UploadToRecitationSurahTrackFilesTest(TestCase):
+    """Tests for upload_to_recitation_surah_track_files path generation."""
+
+    def test_upload_to_recitation_surah_track_files_where_ids_set_should_return_correct_path(self) -> None:
+        """Verify correct path with valid asset_id and surah_number."""
+        instance = SimpleNamespace(asset_id=6, surah_number=2)
+        result = upload_to_recitation_surah_track_files(instance, "track.mp3")
+        self.assertEqual(result, "uploads/assets/6/recitations/002.mp3")
+
+    def test_upload_to_recitation_surah_track_files_where_asset_id_is_none_should_not_contain_none(self) -> None:
+        """Verify that /None/ never appears when asset_id is None."""
+        instance = SimpleNamespace(asset_id=None, surah_number=114)
+        result = upload_to_recitation_surah_track_files(instance, "track.mp3")
+        self.assertNotIn("None", result)
+        self.assertTrue(result.endswith("/recitations/114.mp3"))

--- a/apps/core/test_uploads.py
+++ b/apps/core/test_uploads.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 
 from apps.core.uploads import (
-    _safe_id,
+    _safe_own_id,
     upload_to_asset_files,
     upload_to_asset_preview_images,
     upload_to_asset_thumbnails,
@@ -13,29 +13,29 @@ from apps.core.uploads import (
 )
 
 
-class SafeIdTest(TestCase):
-    """Tests for the _safe_id helper that prevents None in file paths."""
+class SafeOwnIdTest(TestCase):
+    """Tests for the _safe_own_id helper that prevents None in file paths."""
 
-    def test_safe_id_where_id_is_integer_should_return_string_of_id(self) -> None:
+    def test_safe_own_id_where_id_is_integer_should_return_string_of_id(self) -> None:
         """Verify that a valid integer ID is returned as its string representation."""
-        result = _safe_id(42)
+        result = _safe_own_id(42)
         self.assertEqual(result, "42")
 
-    def test_safe_id_where_id_is_none_should_return_uuid_fallback(self) -> None:
+    def test_safe_own_id_where_id_is_none_should_return_uuid_fallback(self) -> None:
         """Verify that None produces a 12-character hex fallback instead of 'None'."""
-        result = _safe_id(None)
+        result = _safe_own_id(None)
         self.assertNotEqual(result, "None")
         self.assertEqual(len(result), 12)
         self.assertTrue(all(c in "0123456789abcdef" for c in result))
 
-    def test_safe_id_where_id_is_none_should_return_unique_values(self) -> None:
+    def test_safe_own_id_where_id_is_none_should_return_unique_values(self) -> None:
         """Verify that repeated calls with None produce different fallbacks."""
-        results = {_safe_id(None) for _ in range(10)}
+        results = {_safe_own_id(None) for _ in range(10)}
         self.assertEqual(len(results), 10)
 
-    def test_safe_id_where_id_is_zero_should_return_zero_string(self) -> None:
+    def test_safe_own_id_where_id_is_zero_should_return_zero_string(self) -> None:
         """Verify that zero is treated as a valid ID, not as falsy."""
-        result = _safe_id(0)
+        result = _safe_own_id(0)
         self.assertEqual(result, "0")
 
 
@@ -56,21 +56,17 @@ class UploadToAssetFilesTest(TestCase):
         self.assertTrue(result.startswith("uploads/assets/5/versions/"))
         self.assertTrue(result.endswith("/document.pdf"))
 
-    def test_upload_to_asset_files_where_asset_id_is_none_should_not_contain_none(self) -> None:
-        """Verify that /None/ never appears in the path when asset_id is None."""
+    def test_upload_to_asset_files_where_asset_id_is_none_should_raise_value_error(self) -> None:
+        """Verify that ValueError is raised when asset_id (parent) is None."""
         instance = SimpleNamespace(asset_id=None, id=10)
-        result = upload_to_asset_files(instance, "document.pdf")
-        self.assertNotIn("None", result)
-        self.assertTrue(result.startswith("uploads/assets/"))
-        self.assertIn("/versions/10/document.pdf", result)
+        with self.assertRaisesRegex(ValueError, "Asset must be saved"):
+            upload_to_asset_files(instance, "document.pdf")
 
-    def test_upload_to_asset_files_where_both_ids_none_should_not_contain_none(self) -> None:
-        """Verify that /None/ never appears when both IDs are None."""
+    def test_upload_to_asset_files_where_both_ids_none_should_raise_value_error(self) -> None:
+        """Verify that ValueError is raised when asset_id (parent) is None."""
         instance = SimpleNamespace(asset_id=None, id=None)
-        result = upload_to_asset_files(instance, "document.pdf")
-        self.assertNotIn("None", result)
-        self.assertTrue(result.startswith("uploads/assets/"))
-        self.assertTrue(result.endswith(".pdf"))
+        with self.assertRaisesRegex(ValueError, "Asset must be saved"):
+            upload_to_asset_files(instance, "document.pdf")
 
 
 class UploadToResourceFilesTest(TestCase):
@@ -133,11 +129,11 @@ class UploadToAssetPreviewImagesTest(TestCase):
         result = upload_to_asset_preview_images(instance, "preview shot.png")
         self.assertEqual(result, "uploads/assets/4/preview/preview-shot.png")
 
-    def test_upload_to_asset_preview_images_where_asset_id_is_none_should_not_contain_none(self) -> None:
-        """Verify that /None/ never appears when asset_id is None."""
+    def test_upload_to_asset_preview_images_where_asset_id_is_none_should_raise_value_error(self) -> None:
+        """Verify that ValueError is raised when asset_id (parent) is None."""
         instance = SimpleNamespace(asset_id=None)
-        result = upload_to_asset_preview_images(instance, "shot.png")
-        self.assertNotIn("None", result)
+        with self.assertRaisesRegex(ValueError, "Asset must be saved"):
+            upload_to_asset_preview_images(instance, "shot.png")
 
 
 class UploadToReciterImageTest(TestCase):
@@ -165,9 +161,8 @@ class UploadToRecitationSurahTrackFilesTest(TestCase):
         result = upload_to_recitation_surah_track_files(instance, "track.mp3")
         self.assertEqual(result, "uploads/assets/6/recitations/002.mp3")
 
-    def test_upload_to_recitation_surah_track_files_where_asset_id_is_none_should_not_contain_none(self) -> None:
-        """Verify that /None/ never appears when asset_id is None."""
+    def test_upload_to_recitation_surah_track_files_where_asset_id_is_none_should_raise_value_error(self) -> None:
+        """Verify that ValueError is raised when asset_id (parent) is None."""
         instance = SimpleNamespace(asset_id=None, surah_number=114)
-        result = upload_to_recitation_surah_track_files(instance, "track.mp3")
-        self.assertNotIn("None", result)
-        self.assertTrue(result.endswith("/recitations/114.mp3"))
+        with self.assertRaisesRegex(ValueError, "Asset must be saved"):
+            upload_to_recitation_surah_track_files(instance, "track.mp3")

--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
 
 
 def _safe_id(instance_id: int | None) -> str:
+    """Return the instance ID as a string, or a UUID-based fallback if the ID is None.
+
+    Prevents '/None' from appearing in upload paths when the model instance
+    has not yet been saved to the database.
+    """
     if instance_id is None:
         return str(uuid.uuid4().hex[:12])
     return str(instance_id)

--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -15,78 +15,64 @@ if TYPE_CHECKING:
     from apps.publishers.models import Publisher
 
 
-def _safe_id(instance_id: int | None) -> str:
-    """Return the instance ID as a string, or a UUID-based fallback if the ID is None.
+def _safe_own_id(instance_id: int | None) -> str:
+    """Return the instance's own ID as a string, or a UUID fallback if unsaved.
 
-    Prevents '/None' from appearing in upload paths when the model instance
-    has not yet been saved to the database.
+    Only use for the instance's own primary key - never for foreign key
+    references to parent objects, which should always be saved first.
     """
     if instance_id is None:
         return str(uuid.uuid4().hex[:12])
     return str(instance_id)
 
 
+def _require_parent_id(parent_id: int | None, parent_name: str) -> str:
+    """Return the parent ID as a string, raising ValueError if None.
+
+    Parent objects must be saved before creating child upload paths.
+    """
+    if parent_id is None:
+        raise ValueError(f"{parent_name} must be saved before uploading files.")
+    return str(parent_id)
+
+
 def upload_to_publisher_icons(instance: "Publisher", filename: str) -> str:
-    """
-    Generate upload path for publisher icon images
-    Format: uploads/publishers/{publisher_id}/icon.{ext}
-    """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/publishers/{_safe_id(instance.id)}/{filename}"
+    return f"uploads/publishers/{_safe_own_id(instance.id)}/{filename}"
 
 
 def upload_to_asset_thumbnails(instance: "Asset", filename: str) -> str:
-    """
-    Generate upload path for asset thumbnail images
-    Format: uploads/assets/{asset_id}/thumbnail.{ext}
-    """
     ext = filename.split(".")[-1].lower()
     filename = f"thumbnail.{ext}"
-    return f"uploads/assets/{_safe_id(instance.id)}/{filename}"
+    return f"uploads/assets/{_safe_own_id(instance.id)}/{filename}"
 
 
 def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> str:
-    """
-    Generate upload path for asset preview images
-    Format: uploads/assets/{asset_id}/preview/{filename}
-    """
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/assets/{_safe_id(instance.asset_id)}/preview/{safe_filename}"
+    asset_id = _require_parent_id(instance.asset_id, "Asset")
+    return f"uploads/assets/{asset_id}/preview/{safe_filename}"
 
 
 def upload_to_asset_files(instance: "AssetVersion", filename: str) -> str:
-    """
-    Generate upload path for asset version files
-    Format: uploads/assets/{asset_id}/versions/{asset_version_id}/{filename}
-    """
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/assets/{_safe_id(instance.asset_id)}/versions/{_safe_id(instance.id)}/{safe_filename}"
+    asset_id = _require_parent_id(instance.asset_id, "Asset")
+    return f"uploads/assets/{asset_id}/versions/{_safe_own_id(instance.id)}/{safe_filename}"
 
 
 def upload_to_resource_files(instance: "ResourceVersion", filename: str) -> str:
-    """
-    Generate upload path for resource version files
-    Format: uploads/resources/{resource_id}/versions/{resource_version_id}/{filename}
-    """
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/resources/{_safe_id(instance.resource_id)}/versions/{_safe_id(instance.id)}/{safe_filename}"
+    resource_id = _require_parent_id(instance.resource_id, "Resource")
+    return f"uploads/resources/{resource_id}/versions/{_safe_own_id(instance.id)}/{safe_filename}"
 
 
 def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", filename: str) -> str:
-    """
-    Generate upload path for recitation surah track audio files.
-    Format: uploads/assets/{asset_id}/recitations/{surah_number:03}.{ext}
-    """
     ext = filename.split(".")[-1].lower() if "." in filename else "mp3"
-    return f"uploads/assets/{_safe_id(instance.asset_id)}/recitations/{int(instance.surah_number):03}.{ext}"
+    asset_id = _require_parent_id(instance.asset_id, "Asset")
+    return f"uploads/assets/{asset_id}/recitations/{int(instance.surah_number):03}.{ext}"
 
 
 def upload_to_reciter_image(instance: "Reciter", filename: str) -> str:
-    """
-    Generate upload path for reciter icon images
-    Format: uploads/reciters/{reciter_id}/image.{ext}
-    """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/reciters/{_safe_id(instance.id)}/{filename}"
+    return f"uploads/reciters/{_safe_own_id(instance.id)}/{filename}"

--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import TYPE_CHECKING
 
 from django.utils.text import slugify
@@ -14,6 +15,12 @@ if TYPE_CHECKING:
     from apps.publishers.models import Publisher
 
 
+def _safe_id(instance_id: int | None) -> str:
+    if instance_id is None:
+        return str(uuid.uuid4().hex[:12])
+    return str(instance_id)
+
+
 def upload_to_publisher_icons(instance: "Publisher", filename: str) -> str:
     """
     Generate upload path for publisher icon images
@@ -21,7 +28,7 @@ def upload_to_publisher_icons(instance: "Publisher", filename: str) -> str:
     """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/publishers/{instance.id}/{filename}"
+    return f"uploads/publishers/{_safe_id(instance.id)}/{filename}"
 
 
 def upload_to_asset_thumbnails(instance: "Asset", filename: str) -> str:
@@ -31,7 +38,7 @@ def upload_to_asset_thumbnails(instance: "Asset", filename: str) -> str:
     """
     ext = filename.split(".")[-1].lower()
     filename = f"thumbnail.{ext}"
-    return f"uploads/assets/{instance.id}/{filename}"
+    return f"uploads/assets/{_safe_id(instance.id)}/{filename}"
 
 
 def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> str:
@@ -40,7 +47,7 @@ def upload_to_asset_preview_images(instance: "AssetPreview", filename: str) -> s
     Format: uploads/assets/{asset_id}/preview/{filename}
     """
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/assets/{instance.asset_id}/preview/{safe_filename}"
+    return f"uploads/assets/{_safe_id(instance.asset_id)}/preview/{safe_filename}"
 
 
 def upload_to_asset_files(instance: "AssetVersion", filename: str) -> str:
@@ -48,9 +55,8 @@ def upload_to_asset_files(instance: "AssetVersion", filename: str) -> str:
     Generate upload path for asset version files
     Format: uploads/assets/{asset_id}/versions/{asset_version_id}/{filename}
     """
-    # Keep original filename for downloadable assets
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/assets/{instance.asset_id}/versions/{instance.id}/{safe_filename}"
+    return f"uploads/assets/{_safe_id(instance.asset_id)}/versions/{_safe_id(instance.id)}/{safe_filename}"
 
 
 def upload_to_resource_files(instance: "ResourceVersion", filename: str) -> str:
@@ -58,9 +64,8 @@ def upload_to_resource_files(instance: "ResourceVersion", filename: str) -> str:
     Generate upload path for resource version files
     Format: uploads/resources/{resource_id}/versions/{resource_version_id}/{filename}
     """
-    # Keep original filename for downloadable resources
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
-    return f"uploads/resources/{instance.resource_id}/versions/{instance.id}/{safe_filename}"
+    return f"uploads/resources/{_safe_id(instance.resource_id)}/versions/{_safe_id(instance.id)}/{safe_filename}"
 
 
 def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", filename: str) -> str:
@@ -69,14 +74,14 @@ def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", fil
     Format: uploads/assets/{asset_id}/recitations/{surah_number:03}.{ext}
     """
     ext = filename.split(".")[-1].lower() if "." in filename else "mp3"
-    return f"uploads/assets/{instance.asset_id}/recitations/{int(instance.surah_number):03}.{ext}"
+    return f"uploads/assets/{_safe_id(instance.asset_id)}/recitations/{int(instance.surah_number):03}.{ext}"
 
 
 def upload_to_reciter_image(instance: "Reciter", filename: str) -> str:
     """
-    Generate upload path for publisher icon images
+    Generate upload path for reciter icon images
     Format: uploads/reciters/{reciter_id}/image.{ext}
     """
     ext = filename.split(".")[-1].lower()
     filename = f"icon.{ext}"
-    return f"uploads/reciters/{instance.id}/{filename}"
+    return f"uploads/reciters/{_safe_id(instance.id)}/{filename}"


### PR DESCRIPTION
## Summary

- **Issue #134**: Upload path functions (`upload_to_asset_files`, `upload_to_resource_files`, etc.) produced paths containing `/None/` when `instance.id` was not yet assigned (before first save). Added `_safe_id()` helper that generates a UUID-based fallback when the instance ID is `None`, preventing invalid path segments across all upload functions.

- **Issue #135**: Enhanced `NinjaPagination` to return `total`, `page`, `pageSize`, `totalPages`, `nextPage`, and `prevPage` alongside existing `results`/`count` fields. This enables proper UI pagination with page navigation controls.

Fixes #134
Fixes #135

## Changes

- `apps/core/uploads.py` - Added `_safe_id()` helper with docstring, applied to all upload path functions
- `apps/core/test_uploads.py` - Added 20 unit tests covering all upload path functions with None ID scenarios
- `apps/core/ninja_utils/paginations.py` - Extended `NinjaPagination.Output` schema with pagination metadata fields
- `apps/content/tests/internal/test_resources.py` - Added pagination structure assertions and page navigation tests

## Test plan

- [x] Verify `_safe_id` returns string of ID when ID is set
- [x] Verify `_safe_id` returns 12-char hex fallback when ID is None
- [x] Verify `upload_to_asset_files` returns valid path when `instance.id` is `None`
- [x] Verify `upload_to_asset_files` returns correct path when `instance.id` is set
- [x] Verify all other upload functions handle None IDs without producing `/None/` paths
- [x] Verify `GET /resources/?page=1&page_size=2` returns correct pagination metadata
- [x] Verify `nextPage` is `null` on last page and `prevPage` is `null` on first page
- [x] Verify backward compatibility: `results` and `count` fields still present
- [x] All 20 upload tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination responses now include full metadata: total count, current page, page size, total pages, and next/previous links.

* **Bug Fixes**
  * Upload path generation made robust: IDs are normalized, filenames sanitized, and missing parent objects produce explicit errors instead of invalid paths.

* **Tests**
  * Added pagination tests for first/last page behavior.
  * Added extensive upload-path tests covering null IDs, formatting, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->