### PR TITLE
feat: add portal list publishers endpoint with filters and search

### DIFF
--- a/apps/publishers/api/portal/create_publisher.py
+++ b/apps/publishers/api/portal/create_publisher.py
@@ -1,0 +1,62 @@
+from ninja import Schema
+from pydantic import AwareDatetime
+
+from apps.core.ninja_utils.auth import ninja_jwt_auth
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+from apps.publishers.repositories.publisher import PublisherRepository
+from apps.publishers.services.publisher import PublisherService
+
+router = ItqanRouter(tags=[NinjaTag.PUBLISHERS])
+
+
+class PublisherCreateIn(Schema):
+    name: str
+    name_ar: str = ""
+    name_en: str = ""
+    description: str = ""
+    description_ar: str = ""
+    address: str = ""
+    website: str = ""
+    contact_email: str = ""
+    is_verified: bool = True
+    foundation_year: int | None = None
+    country: str = ""
+
+
+class PublisherCreateOut(Schema):
+    id: int
+    name: str
+    slug: str
+    name_ar: str | None
+    name_en: str | None
+    description: str
+    description_ar: str | None
+    address: str
+    website: str
+    contact_email: str
+    is_verified: bool
+    foundation_year: int | None
+    country: str
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+
+
+@router.post("publishers/", response={201: PublisherCreateOut}, auth=ninja_jwt_auth)
+def create_publisher(request: Request, data: PublisherCreateIn) -> tuple[int, object]:
+    service = PublisherService(PublisherRepository())
+    publisher = service.create_publisher(
+        name=data.name,
+        name_ar=data.name_ar,
+        name_en=data.name_en,
+        description=data.description,
+        description_ar=data.description_ar,
+        address=data.address,
+        website=data.website,
+        contact_email=data.contact_email,
+        is_verified=data.is_verified,
+        foundation_year=data.foundation_year,
+        country=data.country,
+    )
+    return 201, publisher

--- a/apps/publishers/api/portal/publishers.py
+++ b/apps/publishers/api/portal/publishers.py
@@ -3,6 +3,7 @@ from ninja.pagination import paginate
 from pydantic import AwareDatetime
 
 from apps.core.ninja_utils.auth import ninja_jwt_auth
+from apps.core.ninja_utils.errors import NinjaErrorResponse
 from apps.core.ninja_utils.paginations import NinjaPagination
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
@@ -47,7 +48,7 @@ class PublisherCreateOut(Schema):
     updated_at: AwareDatetime
 
 
-@router.post("publishers/", response={201: PublisherCreateOut}, auth=ninja_jwt_auth)
+@router.post("publishers/", response={201: PublisherCreateOut, 400: NinjaErrorResponse}, auth=ninja_jwt_auth)
 def create_publisher(request: Request, data: PublisherCreateIn) -> tuple[int, object]:
     service = PublisherService(PublisherRepository())
     publisher = service.create_publisher(

--- a/apps/publishers/api/portal/publishers.py
+++ b/apps/publishers/api/portal/publishers.py
@@ -1,10 +1,14 @@
-from ninja import Schema
+from ninja import FilterSchema, Query, Schema
+from ninja.pagination import paginate
 from pydantic import AwareDatetime
 
 from apps.core.ninja_utils.auth import ninja_jwt_auth
+from apps.core.ninja_utils.paginations import NinjaPagination
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.searching_base import searching
 from apps.core.ninja_utils.tags import NinjaTag
+from apps.publishers.models import Publisher
 from apps.publishers.repositories.publisher import PublisherRepository
 from apps.publishers.services.publisher import PublisherService
 
@@ -60,3 +64,30 @@ def create_publisher(request: Request, data: PublisherCreateIn) -> tuple[int, ob
         country=data.country,
     )
     return 201, publisher
+
+
+# --- List Publishers ---
+
+
+class PublisherListOut(Schema):
+    id: int
+    name: str
+    slug: str
+    is_verified: bool
+    country: str
+    foundation_year: int | None
+    created_at: AwareDatetime
+
+
+class PublisherFilter(FilterSchema):
+    is_verified: bool | None = None
+    country: str | None = None
+
+
+@router.get("publishers/", response=list[PublisherListOut], auth=ninja_jwt_auth)
+@paginate(NinjaPagination)
+@searching(search_fields=["name", "name_ar", "description", "description_ar"])
+def list_publishers(request: Request, filters: PublisherFilter = Query(...)):
+    qs = Publisher.objects.all()
+    qs = filters.filter(qs)
+    return qs

--- a/apps/publishers/repositories/publisher.py
+++ b/apps/publishers/repositories/publisher.py
@@ -1,0 +1,9 @@
+from apps.publishers.models import Publisher
+
+
+class PublisherRepository:
+    def create(self, **kwargs: object) -> Publisher:
+        return Publisher.objects.create(**kwargs)
+
+    def slug_exists(self, slug: str) -> bool:
+        return Publisher.objects.filter(slug=slug).exists()

--- a/apps/publishers/services/publisher.py
+++ b/apps/publishers/services/publisher.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from django.utils.text import slugify
 
 from apps.core.ninja_utils.errors import ItqanError
@@ -58,4 +59,11 @@ class PublisherService:
         if description_ar:
             kwargs["description_ar"] = description_ar
 
-        return self.repo.create(**kwargs)
+        try:
+            return self.repo.create(**kwargs)
+        except IntegrityError as exc:
+            raise ItqanError(
+                error_name="publisher_already_exists",
+                message=f"A publisher with slug '{slug}' already exists",
+                status_code=400,
+            ) from exc

--- a/apps/publishers/services/publisher.py
+++ b/apps/publishers/services/publisher.py
@@ -1,0 +1,61 @@
+from django.utils.text import slugify
+
+from apps.core.ninja_utils.errors import ItqanError
+from apps.publishers.models import Publisher
+from apps.publishers.repositories.publisher import PublisherRepository
+
+
+class PublisherService:
+    def __init__(self, repo: PublisherRepository) -> None:
+        self.repo = repo
+
+    def create_publisher(
+        self,
+        *,
+        name: str,
+        name_ar: str = "",
+        name_en: str = "",
+        description: str = "",
+        description_ar: str = "",
+        address: str = "",
+        website: str = "",
+        contact_email: str = "",
+        is_verified: bool = True,
+        foundation_year: int | None = None,
+        country: str = "",
+    ) -> Publisher:
+        if not name or not name.strip():
+            raise ItqanError(
+                error_name="publisher_name_required",
+                message="Publisher name is required",
+                status_code=400,
+            )
+
+        slug = slugify(name[:50], allow_unicode=True)
+
+        if self.repo.slug_exists(slug):
+            raise ItqanError(
+                error_name="publisher_already_exists",
+                message=f"A publisher with slug '{slug}' already exists",
+                status_code=400,
+            )
+
+        kwargs: dict[str, object] = {
+            "name": name.strip(),
+            "slug": slug,
+            "description": description,
+            "address": address,
+            "website": website,
+            "contact_email": contact_email,
+            "is_verified": is_verified,
+            "foundation_year": foundation_year,
+            "country": country,
+        }
+        if name_ar:
+            kwargs["name_ar"] = name_ar
+        if name_en:
+            kwargs["name_en"] = name_en
+        if description_ar:
+            kwargs["description_ar"] = description_ar
+
+        return self.repo.create(**kwargs)

--- a/apps/publishers/tests/portal/test_create_publisher.py
+++ b/apps/publishers/tests/portal/test_create_publisher.py
@@ -8,11 +8,11 @@ from apps.users.models import User
 class CreatePublisherTest(BaseTestCase):
     def setUp(self) -> None:
         self.user = baker.make(User)
-        self.authenticate_user(self.user)
         self.url = "/portal/publishers/"
 
     def test_create_publisher_where_all_fields_provided_should_return_201(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         data = {
             "name": "Tafsir Center",
             "name_ar": "مركز التفسير",
@@ -49,6 +49,7 @@ class CreatePublisherTest(BaseTestCase):
 
     def test_create_publisher_where_only_name_provided_should_return_201_with_defaults(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         data = {"name": "Minimal Publisher"}
 
         # Act
@@ -66,6 +67,7 @@ class CreatePublisherTest(BaseTestCase):
 
     def test_create_publisher_where_name_empty_should_return_400(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         data = {"name": ""}
 
         # Act
@@ -78,6 +80,7 @@ class CreatePublisherTest(BaseTestCase):
 
     def test_create_publisher_where_duplicate_slug_should_return_400(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Test Publisher", slug="test-publisher")
         data = {"name": "Test Publisher"}
 
@@ -91,6 +94,7 @@ class CreatePublisherTest(BaseTestCase):
 
     def test_create_publisher_where_translated_fields_provided_should_store_correctly(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         data = {
             "name": "International Publisher",
             "name_ar": "الناشر الدولي",
@@ -112,10 +116,10 @@ class CreatePublisherTest(BaseTestCase):
         publisher = Publisher.objects.get(id=body["id"])
         self.assertEqual("الناشر الدولي", publisher.name_ar)
         self.assertEqual("International Publisher EN", publisher.name_en)
+        self.assertEqual("وصف بالعربية", publisher.description_ar)
 
     def test_create_publisher_where_unauthenticated_should_return_401(self) -> None:
         # Arrange
-        self.authenticate_user(None)
         data = {"name": "Test Publisher"}
 
         # Act

--- a/apps/publishers/tests/portal/test_create_publisher.py
+++ b/apps/publishers/tests/portal/test_create_publisher.py
@@ -1,0 +1,125 @@
+from model_bakery import baker
+
+from apps.core.tests import BaseTestCase
+from apps.publishers.models import Publisher
+from apps.users.models import User
+
+
+class CreatePublisherTest(BaseTestCase):
+    def setUp(self) -> None:
+        self.user = baker.make(User)
+        self.authenticate_user(self.user)
+        self.url = "/portal/publishers/"
+
+    def test_create_publisher_where_all_fields_provided_should_return_201(self) -> None:
+        # Arrange
+        data = {
+            "name": "Tafsir Center",
+            "name_ar": "مركز التفسير",
+            "description": "A leading Tafsir publisher",
+            "description_ar": "ناشر رائد في التفسير",
+            "address": "Riyadh, KSA",
+            "website": "https://tafsir.center",
+            "contact_email": "info@tafsir.center",
+            "is_verified": True,
+            "foundation_year": 2010,
+            "country": "Saudi Arabia",
+        }
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("Tafsir Center", body["name"])
+        self.assertEqual("tafsir-center", body["slug"])
+        self.assertEqual("مركز التفسير", body["name_ar"])
+        self.assertEqual("A leading Tafsir publisher", body["description"])
+        self.assertEqual("ناشر رائد في التفسير", body["description_ar"])
+        self.assertEqual("Riyadh, KSA", body["address"])
+        self.assertEqual("https://tafsir.center", body["website"])
+        self.assertEqual("info@tafsir.center", body["contact_email"])
+        self.assertTrue(body["is_verified"])
+        self.assertEqual(2010, body["foundation_year"])
+        self.assertEqual("Saudi Arabia", body["country"])
+        self.assertIn("id", body)
+        self.assertIn("created_at", body)
+        self.assertIn("updated_at", body)
+
+    def test_create_publisher_where_only_name_provided_should_return_201_with_defaults(self) -> None:
+        # Arrange
+        data = {"name": "Minimal Publisher"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("Minimal Publisher", body["name"])
+        self.assertEqual("minimal-publisher", body["slug"])
+        self.assertEqual("", body["description"])
+        self.assertEqual("", body["address"])
+        self.assertTrue(body["is_verified"])
+        self.assertIsNone(body["foundation_year"])
+
+    def test_create_publisher_where_name_empty_should_return_400(self) -> None:
+        # Arrange
+        data = {"name": ""}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("publisher_name_required", body["error_name"])
+
+    def test_create_publisher_where_duplicate_slug_should_return_400(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Test Publisher", slug="test-publisher")
+        data = {"name": "Test Publisher"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("publisher_already_exists", body["error_name"])
+
+    def test_create_publisher_where_translated_fields_provided_should_store_correctly(self) -> None:
+        # Arrange
+        data = {
+            "name": "International Publisher",
+            "name_ar": "الناشر الدولي",
+            "name_en": "International Publisher EN",
+            "description_ar": "وصف بالعربية",
+        }
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("الناشر الدولي", body["name_ar"])
+        self.assertEqual("International Publisher EN", body["name_en"])
+        self.assertEqual("وصف بالعربية", body["description_ar"])
+
+        # Verify in database
+        publisher = Publisher.objects.get(id=body["id"])
+        self.assertEqual("الناشر الدولي", publisher.name_ar)
+        self.assertEqual("International Publisher EN", publisher.name_en)
+
+    def test_create_publisher_where_unauthenticated_should_return_401(self) -> None:
+        # Arrange
+        self.authenticate_user(None)
+        data = {"name": "Test Publisher"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(401, response.status_code, response.content)

--- a/apps/publishers/tests/portal/test_list_publishers.py
+++ b/apps/publishers/tests/portal/test_list_publishers.py
@@ -1,0 +1,107 @@
+from model_bakery import baker
+
+from apps.core.tests import BaseTestCase
+from apps.publishers.models import Publisher
+from apps.users.models import User
+
+
+class ListPublishersTest(BaseTestCase):
+    def setUp(self) -> None:
+        self.user = baker.make(User)
+        self.authenticate_user(self.user)
+        self.url = "/portal/publishers/"
+
+    def test_list_publishers_where_no_filters_should_return_all_paginated(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Publisher A", slug="publisher-a")
+        baker.make(Publisher, name="Publisher B", slug="publisher-b")
+        baker.make(Publisher, name="Publisher C", slug="publisher-c")
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(3, body["count"])
+        self.assertEqual(3, len(body["results"]))
+
+    def test_list_publishers_where_search_by_name_should_filter_results(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Tafsir Center", slug="tafsir-center")
+        baker.make(Publisher, name="Hadith Press", slug="hadith-press")
+
+        # Act
+        response = self.client.get(self.url, {"search": "Tafsir"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Tafsir Center", body["results"][0]["name"])
+
+    def test_list_publishers_where_search_by_name_ar_should_filter_results(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Tafsir Center", name_ar="مركز التفسير", slug="tafsir-center")
+        baker.make(Publisher, name="Hadith Press", name_ar="دار الحديث", slug="hadith-press")
+
+        # Act
+        response = self.client.get(self.url, {"search": "التفسير"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Tafsir Center", body["results"][0]["name"])
+
+    def test_list_publishers_where_filter_is_verified_true_should_return_only_verified(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Verified Pub", slug="verified-pub", is_verified=True)
+        baker.make(Publisher, name="Unverified Pub", slug="unverified-pub", is_verified=False)
+
+        # Act
+        response = self.client.get(self.url, {"is_verified": "true"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Verified Pub", body["results"][0]["name"])
+
+    def test_list_publishers_where_filter_country_should_filter_results(self) -> None:
+        # Arrange
+        baker.make(Publisher, name="Saudi Pub", slug="saudi-pub", country="Saudi Arabia")
+        baker.make(Publisher, name="Egypt Pub", slug="egypt-pub", country="Egypt")
+
+        # Act
+        response = self.client.get(self.url, {"country": "Saudi Arabia"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Saudi Pub", body["results"][0]["name"])
+
+    def test_list_publishers_where_page_2_should_return_correct_offset(self) -> None:
+        # Arrange
+        for i in range(25):
+            baker.make(Publisher, name=f"Publisher {i:02d}", slug=f"publisher-{i:02d}")
+
+        # Act
+        response = self.client.get(self.url, {"page": 2, "page_size": 20})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(25, body["count"])
+        self.assertEqual(5, len(body["results"]))
+
+    def test_list_publishers_where_unauthenticated_should_return_401(self) -> None:
+        # Arrange
+        self.authenticate_user(None)
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(401, response.status_code, response.content)

--- a/apps/publishers/tests/portal/test_list_publishers.py
+++ b/apps/publishers/tests/portal/test_list_publishers.py
@@ -8,11 +8,11 @@ from apps.users.models import User
 class ListPublishersTest(BaseTestCase):
     def setUp(self) -> None:
         self.user = baker.make(User)
-        self.authenticate_user(self.user)
         self.url = "/portal/publishers/"
 
     def test_list_publishers_where_no_filters_should_return_all_paginated(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Publisher A", slug="publisher-a")
         baker.make(Publisher, name="Publisher B", slug="publisher-b")
         baker.make(Publisher, name="Publisher C", slug="publisher-c")
@@ -28,6 +28,7 @@ class ListPublishersTest(BaseTestCase):
 
     def test_list_publishers_where_search_by_name_should_filter_results(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Tafsir Center", slug="tafsir-center")
         baker.make(Publisher, name="Hadith Press", slug="hadith-press")
 
@@ -42,6 +43,7 @@ class ListPublishersTest(BaseTestCase):
 
     def test_list_publishers_where_search_by_name_ar_should_filter_results(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Tafsir Center", name_ar="مركز التفسير", slug="tafsir-center")
         baker.make(Publisher, name="Hadith Press", name_ar="دار الحديث", slug="hadith-press")
 
@@ -54,8 +56,24 @@ class ListPublishersTest(BaseTestCase):
         self.assertEqual(1, body["count"])
         self.assertEqual("Tafsir Center", body["results"][0]["name"])
 
+    def test_list_publishers_where_search_by_description_should_filter_results(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        baker.make(Publisher, name="Tafsir Pub", slug="tafsir-pub", description="Specializes in Quran exegesis")
+        baker.make(Publisher, name="Hadith Pub", slug="hadith-pub", description="Hadith collections")
+
+        # Act
+        response = self.client.get(self.url, {"search": "exegesis"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Tafsir Pub", body["results"][0]["name"])
+
     def test_list_publishers_where_filter_is_verified_true_should_return_only_verified(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Verified Pub", slug="verified-pub", is_verified=True)
         baker.make(Publisher, name="Unverified Pub", slug="unverified-pub", is_verified=False)
 
@@ -70,6 +88,7 @@ class ListPublishersTest(BaseTestCase):
 
     def test_list_publishers_where_filter_country_should_filter_results(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         baker.make(Publisher, name="Saudi Pub", slug="saudi-pub", country="Saudi Arabia")
         baker.make(Publisher, name="Egypt Pub", slug="egypt-pub", country="Egypt")
 
@@ -84,6 +103,7 @@ class ListPublishersTest(BaseTestCase):
 
     def test_list_publishers_where_page_2_should_return_correct_offset(self) -> None:
         # Arrange
+        self.authenticate_user(self.user)
         for i in range(25):
             baker.make(Publisher, name=f"Publisher {i:02d}", slug=f"publisher-{i:02d}")
 
@@ -97,9 +117,6 @@ class ListPublishersTest(BaseTestCase):
         self.assertEqual(5, len(body["results"]))
 
     def test_list_publishers_where_unauthenticated_should_return_401(self) -> None:
-        # Arrange
-        self.authenticate_user(None)
-
         # Act
         response = self.client.get(self.url)
 


### PR DESCRIPTION
## ملخص
يُنفّذ هذا الـ PR الـ endpoint الخاص بعرض قائمة الناشرين عبر Portal API (GET `/portal/publishers/`).

### التغييرات:
- **API Endpoint** (`apps/publishers/api/portal/publishers.py`): تم دمج endpoints الإنشاء والقائمة في ملف واحد
  - `NinjaPagination` مع `page` و `page_size`
  - بحث عبر `name`, `name_ar`, `description`, `description_ar`
  - فلترة حسب `is_verified` و `country`
  - Schema خفيف للقائمة (بدون كل التفاصيل)
- **اختبارات** (`apps/publishers/tests/portal/test_list_publishers.py`): ٧ اختبارات:
  - عرض جميع الناشرين مع الترقيم ✅
  - البحث بالاسم الإنجليزي ✅
  - البحث بالاسم العربي ✅
  - فلترة حسب حالة التوثيق ✅
  - فلترة حسب البلد ✅
  - الصفحة الثانية ✅
  - رفض الطلب بدون مصادقة (401) ✅

### ملاحظة:
- يعتمد هذا الـ PR على #266 (Create Publisher endpoint)
- تم دمج كلا الـ endpoints في ملف واحد لأن Django Ninja لا يدعم ملفات router منفصلة على نفس المسار

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publisher creation endpoint with multilingual name and description support
  * Added publisher listing and search functionality with filtering by verification status and country

* **Tests**
  * Added comprehensive test suite for publisher creation and listing endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->