### PR TITLE
fix: prevent /None in upload file paths when parent FK is missing

### DIFF
--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -48,6 +48,8 @@ def upload_to_asset_files(instance: "AssetVersion", filename: str) -> str:
     Generate upload path for asset version files
     Format: uploads/assets/{asset_id}/versions/{asset_version_id}/{filename}
     """
+    if not instance.asset_id:
+        raise ValueError("Cannot upload file for AssetVersion without an associated asset")
     # Keep original filename for downloadable assets
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
     return f"uploads/assets/{instance.asset_id}/versions/{instance.id}/{safe_filename}"
@@ -58,6 +60,8 @@ def upload_to_resource_files(instance: "ResourceVersion", filename: str) -> str:
     Generate upload path for resource version files
     Format: uploads/resources/{resource_id}/versions/{resource_version_id}/{filename}
     """
+    if not instance.resource_id:
+        raise ValueError("Cannot upload file for ResourceVersion without an associated resource")
     # Keep original filename for downloadable resources
     safe_filename = slugify(filename.rsplit(".", 1)[0]) + "." + filename.split(".")[-1].lower()
     return f"uploads/resources/{instance.resource_id}/versions/{instance.id}/{safe_filename}"
@@ -68,6 +72,8 @@ def upload_to_recitation_surah_track_files(instance: "RecitationSurahTrack", fil
     Generate upload path for recitation surah track audio files.
     Format: uploads/assets/{asset_id}/recitations/{surah_number:03}.{ext}
     """
+    if not instance.asset_id:
+        raise ValueError("Cannot upload file for RecitationSurahTrack without an associated asset")
     ext = filename.split(".")[-1].lower() if "." in filename else "mp3"
     return f"uploads/assets/{instance.asset_id}/recitations/{int(instance.surah_number):03}.{ext}"
 


### PR DESCRIPTION
## ملخص التغييرات

يغلق #134

### المشكلة
دوال `upload_to` في `apps/core/uploads.py` كانت بتولد مسارات ملفات فيها `/None/` لما الـ foreign key (زي `asset_id` أو `resource_id`) يكون `None`. ده كان بيحصل لما يتم إنشاء `AssetVersion` من خلال Django Admin inline قبل ما العلاقة مع الـ Asset تتأسس بالكامل.

### الحل
إضافة تحقق (validation guard) في ثلاث دوال:
- `upload_to_asset_files` - بيتأكد من وجود `asset_id`
- `upload_to_resource_files` - بيتأكد من وجود `resource_id`
- `upload_to_recitation_surah_track_files` - بيتأكد من وجود `asset_id`

الدوال دلوقتي بترمي `ValueError` بدل ما تولد مسارات غلط بشكل صامت.

### قبل الإصلاح
```
uploads/assets/None/versions/123/file.pdf
```

### بعد الإصلاح
```
ValueError: Cannot upload file for AssetVersion without an associated asset
```

## خطة الاختبار
- [ ] التأكد من إن رفع الملفات بيشتغل بشكل طبيعي لما الـ FK موجود
- [ ] التأكد من إن الخطأ بيظهر بشكل واضح لما الـ FK مش موجود
- [ ] مراجعة السجلات القديمة للملفات اللي فيها `/None/` في المسار

🤖 Generated with [Claude Code](https://claude.com/claude-code)