### PR TITLE
feat: add portal Reciter Creation API endpoint

### DIFF
--- a/apps/content/api/portal/reciters.py
+++ b/apps/content/api/portal/reciters.py
@@ -1,0 +1,55 @@
+from ninja import Schema
+from pydantic import AwareDatetime
+
+from apps.content.repositories.reciter import ReciterRepository
+from apps.content.services.reciter_portal import ReciterPortalService
+from apps.core.ninja_utils.auth import ninja_jwt_auth
+from apps.core.ninja_utils.errors import NinjaErrorResponse
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+
+router = ItqanRouter(tags=[NinjaTag.RECITERS])
+
+
+class ReciterCreateIn(Schema):
+    name: str
+    name_ar: str = ""
+    name_en: str = ""
+    bio: str = ""
+    bio_ar: str = ""
+    bio_en: str = ""
+    is_active: bool = True
+
+
+class ReciterCreateOut(Schema):
+    id: int
+    name: str
+    slug: str
+    name_ar: str | None
+    name_en: str | None
+    bio: str
+    bio_ar: str | None
+    bio_en: str | None
+    is_active: bool
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+
+
+@router.post(
+    "reciters/",
+    response={201: ReciterCreateOut, 400: NinjaErrorResponse},
+    auth=ninja_jwt_auth,
+)
+def create_reciter(request: Request, data: ReciterCreateIn) -> tuple[int, object]:
+    service = ReciterPortalService(ReciterRepository())
+    reciter = service.create_reciter(
+        name=data.name,
+        name_ar=data.name_ar,
+        name_en=data.name_en,
+        bio=data.bio,
+        bio_ar=data.bio_ar,
+        bio_en=data.bio_en,
+        is_active=data.is_active,
+    )
+    return 201, reciter

--- a/apps/content/repositories/reciter.py
+++ b/apps/content/repositories/reciter.py
@@ -1,0 +1,9 @@
+from apps.content.models import Reciter
+
+
+class ReciterRepository:
+    def create(self, **kwargs: object) -> Reciter:
+        return Reciter.objects.create(**kwargs)
+
+    def slug_exists(self, slug: str) -> bool:
+        return Reciter.objects.filter(slug=slug).exists()

--- a/apps/content/services/reciter_portal.py
+++ b/apps/content/services/reciter_portal.py
@@ -1,0 +1,62 @@
+from django.db import IntegrityError
+from django.utils.text import slugify
+
+from apps.content.models import Reciter
+from apps.content.repositories.reciter import ReciterRepository
+from apps.core.ninja_utils.errors import ItqanError
+
+
+class ReciterPortalService:
+    def __init__(self, repo: ReciterRepository) -> None:
+        self.repo = repo
+
+    def create_reciter(
+        self,
+        *,
+        name: str,
+        name_ar: str = "",
+        name_en: str = "",
+        bio: str = "",
+        bio_ar: str = "",
+        bio_en: str = "",
+        is_active: bool = True,
+    ) -> Reciter:
+        if not name or not name.strip():
+            raise ItqanError(
+                error_name="reciter_name_required",
+                message="Reciter name is required",
+                status_code=400,
+            )
+
+        slug = slugify(name[:50], allow_unicode=True)
+
+        if self.repo.slug_exists(slug):
+            raise ItqanError(
+                error_name="reciter_already_exists",
+                message=f"A reciter with slug '{slug}' already exists",
+                status_code=400,
+            )
+
+        kwargs: dict[str, object] = {
+            "name": name.strip(),
+            "slug": slug,
+            "bio": bio,
+            "is_active": is_active,
+        }
+        if name_ar:
+            kwargs["name_ar"] = name_ar
+        if name_en:
+            kwargs["name_en"] = name_en
+        if bio_ar:
+            kwargs["bio_ar"] = bio_ar
+        if bio_en:
+            kwargs["bio_en"] = bio_en
+
+        try:
+            return self.repo.create(**kwargs)
+        except IntegrityError as exc:
+            raise ItqanError(
+                error_name="reciter_already_exists",
+                message=f"A reciter with slug '{slug}' already exists",
+                status_code=400,
+            ) from exc

--- a/apps/content/services/reciter_portal.py
+++ b/apps/content/services/reciter_portal.py
@@ -57,6 +57,6 @@ class ReciterPortalService:
         except IntegrityError as exc:
             raise ItqanError(
                 error_name="reciter_already_exists",
-                message=f"A reciter with slug '{slug}' already exists",
+                message="A reciter with this name or slug already exists",
                 status_code=400,
             ) from exc

--- a/apps/content/tests/portal/test_create_reciter.py
+++ b/apps/content/tests/portal/test_create_reciter.py
@@ -83,6 +83,20 @@ class CreateReciterTest(BaseTestCase):
         body = response.json()
         self.assertEqual("reciter_already_exists", body["error_name"])
 
+    def test_create_reciter_where_duplicate_name_should_return_400(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        baker.make(Reciter, name="Test Reciter", slug="different-slug")
+        data = {"name": "Test Reciter"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("reciter_already_exists", body["error_name"])
+
     def test_create_reciter_where_translated_fields_provided_should_store_correctly(self) -> None:
         # Arrange
         self.authenticate_user(self.user)

--- a/apps/content/tests/portal/test_create_reciter.py
+++ b/apps/content/tests/portal/test_create_reciter.py
@@ -1,0 +1,130 @@
+from model_bakery import baker
+
+from apps.content.models import Reciter
+from apps.core.tests import BaseTestCase
+from apps.users.models import User
+
+
+class CreateReciterTest(BaseTestCase):
+    def setUp(self) -> None:
+        self.user = baker.make(User)
+        self.url = "/portal/reciters/"
+
+    def test_create_reciter_where_all_fields_provided_should_return_201(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        data = {
+            "name": "Mishary Rashid Alafasy",
+            "name_ar": "مشاري راشد العفاسي",
+            "name_en": "Mishary Rashid Alafasy",
+            "bio": "A famous Quran reciter from Kuwait",
+            "bio_ar": "قارئ قرآن شهير من الكويت",
+            "bio_en": "A famous Quran reciter from Kuwait",
+            "is_active": True,
+        }
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("Mishary Rashid Alafasy", body["name"])
+        self.assertEqual("mishary-rashid-alafasy", body["slug"])
+        self.assertEqual("مشاري راشد العفاسي", body["name_ar"])
+        self.assertEqual("Mishary Rashid Alafasy", body["name_en"])
+        self.assertEqual("A famous Quran reciter from Kuwait", body["bio"])
+        self.assertEqual("قارئ قرآن شهير من الكويت", body["bio_ar"])
+        self.assertTrue(body["is_active"])
+        self.assertIn("id", body)
+        self.assertIn("created_at", body)
+        self.assertIn("updated_at", body)
+
+    def test_create_reciter_where_only_name_provided_should_return_201_with_defaults(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        data = {"name": "Minimal Reciter"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("Minimal Reciter", body["name"])
+        self.assertEqual("minimal-reciter", body["slug"])
+        self.assertEqual("", body["bio"])
+        self.assertTrue(body["is_active"])
+
+    def test_create_reciter_where_name_empty_should_return_400(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        data = {"name": ""}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("reciter_name_required", body["error_name"])
+
+    def test_create_reciter_where_duplicate_slug_should_return_400(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        baker.make(Reciter, name="Test Reciter", slug="test-reciter")
+        data = {"name": "Test Reciter"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("reciter_already_exists", body["error_name"])
+
+    def test_create_reciter_where_translated_fields_provided_should_store_correctly(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        data = {
+            "name": "Saad Al-Ghamdi",
+            "name_ar": "سعد الغامدي",
+            "bio_ar": "من أشهر قراء القرآن الكريم",
+        }
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("سعد الغامدي", body["name_ar"])
+        self.assertEqual("من أشهر قراء القرآن الكريم", body["bio_ar"])
+
+        # Verify in database
+        reciter = Reciter.objects.get(id=body["id"])
+        self.assertEqual("سعد الغامدي", reciter.name_ar)
+        self.assertEqual("من أشهر قراء القرآن الكريم", reciter.bio_ar)
+
+    def test_create_reciter_where_inactive_should_store_correctly(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        data = {"name": "Inactive Reciter", "is_active": False}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertFalse(body["is_active"])
+
+    def test_create_reciter_where_unauthenticated_should_return_401(self) -> None:
+        # Arrange
+        data = {"name": "Test Reciter"}
+
+        # Act
+        response = self.client.post(self.url, data, content_type="application/json")
+
+        # Assert
+        self.assertEqual(401, response.status_code, response.content)


### PR DESCRIPTION
## ملخص التغييرات

يساهم في #194

### الوصف
إضافة endpoint لإنشاء قارئ جديد عبر Portal API:
**`POST /portal/reciters/`**

### الملفات الجديدة
- `apps/content/repositories/reciter.py` - ReciterRepository للوصول للبيانات
- `apps/content/services/reciter_portal.py` - ReciterPortalService مع:
  - التحقق من اسم القارئ (مطلوب)
  - حماية TOCTOU على تفرد الـ slug (`slug_exists` + `IntegrityError` fallback)
  - دعم حقول الترجمة (name_ar/en, bio_ar/en) مع مراعاة django-modeltranslation
- `apps/content/api/portal/reciters.py` - Portal endpoint مع JWT auth
- `apps/content/tests/portal/test_create_reciter.py` - 7 اختبارات شاملة

### Input Schema
```python
class ReciterCreateIn(Schema):
    name: str          # مطلوب
    name_ar: str = ""  # اختياري
    name_en: str = ""  # اختياري
    bio: str = ""      # اختياري
    bio_ar: str = ""   # اختياري
    bio_en: str = ""   # اختياري
    is_active: bool = True
```

### الأخطاء
- `400` - `reciter_name_required`: الاسم مطلوب
- `400` - `reciter_already_exists`: القارئ موجود بالفعل
- `401` - غير مصرح

### ملاحظة
الموديل الحالي لا يحتوي على حقول الجنسية وتاريخ الميلاد/الوفاة المذكورة في الـ acceptance criteria. يمكن إضافتها في migration منفصل.

## خطة الاختبار
- [x] اختبار إنشاء قارئ بجميع الحقول (201)
- [x] اختبار إنشاء قارئ بالاسم فقط (201 مع القيم الافتراضية)
- [x] اختبار اسم فارغ (400)
- [x] اختبار slug مكرر (400)
- [x] اختبار حقول الترجمة
- [x] اختبار إنشاء قارئ غير نشط
- [x] اختبار عدم المصادقة (401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint (POST /portal/reciters/) to create Reciters with support for name, bio, and localized content fields. Includes automatic slug generation with uniqueness validation and requires JWT authentication.

* **Tests**
  * Added test coverage for Reciter creation including validation, duplicate detection, localization, and authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->