### PR TITLE
Fix N+1 queries in recitation list endpoint

### DIFF
--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -24,7 +24,7 @@ class RecitationRepository(BaseRecitationRepository):
         """
         Returns a queryset of Asset objects.
         """
-        qs = self.asset_model.objects.select_related("resource", "reciter", "riwayah").filter(
+        qs = self.asset_model.objects.select_related("resource", "resource__publisher", "reciter", "riwayah", "qiraah").filter(
             publisher_q,
             category=Resource.CategoryChoice.RECITATION,
             resource__category=Resource.CategoryChoice.RECITATION,

--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -24,7 +24,9 @@ class RecitationRepository(BaseRecitationRepository):
         """
         Returns a queryset of Asset objects.
         """
-        qs = self.asset_model.objects.select_related("resource", "resource__publisher", "reciter", "riwayah", "qiraah").filter(
+        qs = self.asset_model.objects.select_related(
+            "resource", "resource__publisher", "reciter", "riwayah", "qiraah"
+        ).filter(
             publisher_q,
             category=Resource.CategoryChoice.RECITATION,
             resource__category=Resource.CategoryChoice.RECITATION,

--- a/apps/content/tests/internal/test_recitation_list.py
+++ b/apps/content/tests/internal/test_recitation_list.py
@@ -1,3 +1,5 @@
+from django.test.utils import CaptureQueriesContext
+
 from model_bakery import baker
 
 from apps.content.models import Asset, Qiraah, Resource, Riwayah
@@ -189,3 +191,15 @@ class RecitationsListTest(BaseTestCase):
             self.assertIn(field, item, f"Missing field: {field}")
         self.assertIsInstance(item["reciter"], dict)
         self.assertSetEqual(set(item["reciter"].keys()), {"id", "name"})
+
+    # ── Query count ────────────────────────────────────────────
+
+    def test_list_recitations_should_use_constant_number_of_queries(self):
+        self.authenticate_user(self.user)
+        from django.db import connection
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get("/cms-api/recitations/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertLessEqual(len(ctx), 4, f"Expected <= 4 queries, got {len(ctx)}: {[q['sql'] for q in ctx]}")

--- a/apps/content/tests/internal/test_recitation_list.py
+++ b/apps/content/tests/internal/test_recitation_list.py
@@ -1,5 +1,4 @@
 from django.test.utils import CaptureQueriesContext
-
 from model_bakery import baker
 
 from apps.content.models import Asset, Qiraah, Resource, Riwayah
@@ -202,4 +201,5 @@ class RecitationsListTest(BaseTestCase):
             response = self.client.get("/cms-api/recitations/")
 
         self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual(2, len(response.json()["results"]))
         self.assertLessEqual(len(ctx), 4, f"Expected <= 4 queries, got {len(ctx)}: {[q['sql'] for q in ctx]}")


### PR DESCRIPTION
## Summary

- Added `"qiraah"` and `"resource__publisher"` to the `select_related()` call in `list_recitations_qs()` to batch-load all relationships accessed by the serializer
- Added a query count test using `CaptureQueriesContext` asserting the recitation list endpoint uses 4 queries or fewer

## Details

The recitation list endpoint was missing `qiraah` in its `select_related()` call, causing a separate DB query for every recitation when the serializer accessed `asset.qiraah`. The public API serializer also accesses `resource.publisher`, which required adding `resource__publisher` to prevent additional N+1 queries on that path.

With these changes, the endpoint uses a constant number of queries regardless of result count.

## Test plan

- [ ] Existing recitation list tests pass
- [ ] New query count test verifies <= 4 queries for the endpoint
- [ ] API response format unchanged

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved data loading for recitations to further reduce database queries and speed up list responses.

* **Tests**
  * Added a test ensuring recitation list endpoints use a constant, small number of database queries to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->