### PR TITLE
feat: add proper pagination support to resources endpoint

### DIFF
--- a/apps/content/tests/internal/test_recitation_list.py
+++ b/apps/content/tests/internal/test_recitation_list.py
@@ -174,8 +174,8 @@ class RecitationsListTest(BaseTestCase):
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
         self.assertIn("results", body)
-        self.assertIn("count", body)
-        self.assertEqual(2, body["count"])
+        self.assertIn("total", body)
+        self.assertEqual(2, body["total"])
         self.assertEqual(1, len(body["results"]))
 
     # ── Response shape ────────────────────────────────────────

--- a/apps/content/tests/internal/test_reciter_list.py
+++ b/apps/content/tests/internal/test_reciter_list.py
@@ -128,7 +128,7 @@ class RecitersListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         reciter_names = {item["name"] for item in items}
@@ -188,5 +188,5 @@ class RecitersListTest(BaseTestCase):
 
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("مشاري راشد العفاسي", body["results"][0]["name"])

--- a/apps/content/tests/internal/test_resources.py
+++ b/apps/content/tests/internal/test_resources.py
@@ -38,7 +38,7 @@ class ResourceListTest(BaseTestCase):
 
         # Check pagination structure
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         self.assertEqual(2, len(items))
@@ -218,6 +218,113 @@ class ResourceListTest(BaseTestCase):
         self.assertEqual("tafsir", items[0]["category"])
         self.assertEqual("ready", items[0]["status"])
         self.assertEqual(self.publisher1.id, items[0]["publisher"]["id"])
+
+    # Pagination Tests
+    def test_list_resources_pagination_should_return_full_pagination_metadata(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
+
+        # Act
+        response = self.client.get("/cms-api/resources/?page=1&page_size=2")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(2, len(body["results"]))
+        self.assertEqual(5, body["total"])
+        self.assertEqual(1, body["page"])
+        self.assertEqual(2, body["page_size"])
+        self.assertEqual(3, body["total_pages"])
+        self.assertIsNotNone(body["next_page"])
+        self.assertIn("page=2", body["next_page"])
+        self.assertIsNone(body["prev_page"])
+
+    def test_list_resources_pagination_middle_page_should_have_both_next_and_prev(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
+
+        # Act
+        response = self.client.get("/cms-api/resources/?page=2&page_size=2")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(2, len(body["results"]))
+        self.assertEqual(5, body["total"])
+        self.assertEqual(2, body["page"])
+        self.assertEqual(3, body["total_pages"])
+        self.assertIsNotNone(body["next_page"])
+        self.assertIn("page=3", body["next_page"])
+        self.assertIsNotNone(body["prev_page"])
+        self.assertIn("page=1", body["prev_page"])
+
+    def test_list_resources_pagination_last_page_should_have_no_next(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(Resource, publisher=self.publisher1, name=f"Resource {i}")
+
+        # Act
+        response = self.client.get("/cms-api/resources/?page=3&page_size=2")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(1, len(body["results"]))
+        self.assertEqual(5, body["total"])
+        self.assertEqual(3, body["page"])
+        self.assertEqual(3, body["total_pages"])
+        self.assertIsNone(body["next_page"])
+        self.assertIsNotNone(body["prev_page"])
+        self.assertIn("page=2", body["prev_page"])
+
+    def test_list_resources_pagination_preserves_query_params(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        for i in range(5):
+            baker.make(
+                Resource,
+                publisher=self.publisher1,
+                name=f"Resource {i}",
+                category=Resource.CategoryChoice.TAFSIR,
+            )
+
+        # Act
+        response = self.client.get("/cms-api/resources/?page=1&page_size=2&category=tafsir")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertIsNotNone(body["next_page"])
+        self.assertIn("category=tafsir", body["next_page"])
+        self.assertIn("page=2", body["next_page"])
+
+    def test_list_resources_pagination_default_page_size(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        baker.make(Resource, publisher=self.publisher1, name="Resource 1")
+
+        # Act
+        response = self.client.get("/cms-api/resources/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+
+        self.assertEqual(1, body["total"])
+        self.assertEqual(1, body["page"])
+        self.assertEqual(20, body["page_size"])
+        self.assertEqual(1, body["total_pages"])
+        self.assertIsNone(body["next_page"])
+        self.assertIsNone(body["prev_page"])
 
     # CRUD Tests
     def test_create_resource_should_return_200_with_resource_data(self):

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -60,7 +60,7 @@ class RecitationTracksTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         self.assertEqual(2, len(items))

--- a/apps/content/tests/public/test_reciter_list.py
+++ b/apps/content/tests/public/test_reciter_list.py
@@ -97,7 +97,7 @@ class RecitersListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         reciter_names = {item["name"] for item in items}

--- a/apps/content/tests/public/test_riwayah_list.py
+++ b/apps/content/tests/public/test_riwayah_list.py
@@ -127,7 +127,7 @@ class RiwayahsListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         riwayah_names = {item["name"] for item in items}
@@ -232,9 +232,9 @@ class RiwayahsListTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertIn("count", body)
+        self.assertIn("total", body)
         self.assertIn("results", body)
-        self.assertEqual(3, body["count"])  # Should have 3 active riwayahs with recitations
+        self.assertEqual(3, body["total"])  # Should have 3 active riwayahs with recitations
 
     def test_list_riwayahs_pagination_limit_parameter(self):
         """Test pagination with custom limit"""
@@ -247,7 +247,7 @@ class RiwayahsListTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(3, body["count"])  # Total count should still be 3
+        self.assertEqual(3, body["total"])  # Total count should still be 3
 
     def test_list_riwayahs_response_schema(self):
         """Test that response contains all required fields"""
@@ -442,9 +442,9 @@ class RiwayahsListTest(BaseTestCase):
         body = response.json()
 
         # Check pagination fields exist
-        self.assertIn("count", body)
+        self.assertIn("total", body)
         self.assertIn("results", body)
-        self.assertIsInstance(body["count"], int)
+        self.assertIsInstance(body["total"], int)
         self.assertIsInstance(body["results"], list)
 
     def test_list_riwayahs_with_empty_search(self):
@@ -459,7 +459,7 @@ class RiwayahsListTest(BaseTestCase):
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
         # Empty search should return all items
-        self.assertEqual(3, body["count"])
+        self.assertEqual(3, body["total"])
 
     def test_list_riwayahs_response_is_json(self):
         """Test that response is valid JSON"""

--- a/apps/content/tests/tenant/test_qiraah_list.py
+++ b/apps/content/tests/tenant/test_qiraah_list.py
@@ -121,7 +121,7 @@ class QiraahListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         qiraah_names = {item["name"] for item in items}

--- a/apps/content/tests/tenant/test_recitation_detail.py
+++ b/apps/content/tests/tenant/test_recitation_detail.py
@@ -60,7 +60,7 @@ class RecitationTracksTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         self.assertEqual(2, len(items))
@@ -127,7 +127,7 @@ class RecitationTracksTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         self.assertEqual(2, len(items))

--- a/apps/content/tests/tenant/test_reciter_list.py
+++ b/apps/content/tests/tenant/test_reciter_list.py
@@ -91,7 +91,7 @@ class RecitersListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         reciter_names = {item["name"] for item in items}

--- a/apps/content/tests/tenant/test_riwayah_list.py
+++ b/apps/content/tests/tenant/test_riwayah_list.py
@@ -88,7 +88,7 @@ class RiwayahsListTest(BaseTestCase):
         body = response.json()
 
         self.assertIn("results", body)
-        self.assertIn("count", body)
+        self.assertIn("total", body)
 
         items = body["results"]
         riwayah_names = {item["name"] for item in items}

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -1,9 +1,12 @@
+import math
 from typing import Any
+from urllib.parse import urlencode
 
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from ninja import Schema
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
-from pydantic import Field
+from pydantic import Field, field_validator
 
 MAX_PAGE_SIZE = 1000
 DEFAULT_PAGE_SIZE = 20
@@ -16,13 +19,50 @@ class NinjaPagination(NinjaPageNumberPagination):
         page: int = Field(1, ge=1)
         page_size: int = Field(DEFAULT_PAGE_SIZE, ge=1)
 
-        def __init__(self, page_size: int = DEFAULT_PAGE_SIZE, **kwargs: Any) -> None:
-            self.page_size = min(page_size, MAX_PAGE_SIZE)
-            super().__init__(**kwargs)
+        @field_validator("page_size")
+        @classmethod
+        def clamp_page_size(cls, v: int) -> int:
+            return min(v, MAX_PAGE_SIZE)
 
     class Output(Schema):
         results: list[Any]
-        count: int
+        total: int
+        page: int
+        page_size: int
+        total_pages: int
+        next_page: str | None
+        prev_page: str | None
+
+    @staticmethod
+    def _build_page_url(request: HttpRequest | None, page: int, page_size: int) -> str | None:
+        if request is None:
+            return None
+        query = request.GET.copy()
+        query["page"] = str(page)
+        query["page_size"] = str(page_size)
+        return f"{request.path}?{urlencode(query, doseq=True)}"
+
+    def _build_response(
+        self,
+        queryset: QuerySet,
+        pagination: "NinjaPagination.Input",
+        count: int,
+        request: HttpRequest | None = None,
+    ) -> dict[str, Any]:
+        page = pagination.page
+        page_size = pagination.page_size
+        total_pages = math.ceil(count / page_size) if page_size else 0
+        offset = (page - 1) * page_size
+
+        return {
+            "results": queryset[offset : offset + page_size],
+            "total": count,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "next_page": self._build_page_url(request, page + 1, page_size) if page < total_pages else None,
+            "prev_page": self._build_page_url(request, page - 1, page_size) if page > 1 else None,
+        }
 
     def paginate_queryset(
         self,
@@ -30,11 +70,9 @@ class NinjaPagination(NinjaPageNumberPagination):
         pagination: Input,
         **params: Any,
     ) -> Any:
-        offset = (pagination.page - 1) * pagination.page_size
-        return {
-            "results": queryset[offset : offset + pagination.page_size],
-            "count": self._items_count(queryset),
-        }
+        count = self._items_count(queryset)
+        request = params.get("request")
+        return self._build_response(queryset, pagination, count, request)
 
     async def apaginate_queryset(
         self,
@@ -42,8 +80,6 @@ class NinjaPagination(NinjaPageNumberPagination):
         pagination: Input,
         **params: Any,
     ) -> Any:
-        offset = (pagination.page - 1) * pagination.page_size
-        return {
-            "results": queryset[offset : offset + pagination.page_size],
-            "count": await self._aitems_count(queryset),
-        }
+        count = await self._aitems_count(queryset)
+        request = params.get("request")
+        return self._build_response(queryset, pagination, count, request)

--- a/apps/publishers/tests/portal/test_list_publishers.py
+++ b/apps/publishers/tests/portal/test_list_publishers.py
@@ -23,7 +23,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(3, body["count"])
+        self.assertEqual(3, body["total"])
         self.assertEqual(3, len(body["results"]))
 
     def test_list_publishers_where_search_by_name_should_filter_results(self) -> None:
@@ -38,7 +38,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("Tafsir Center", body["results"][0]["name"])
 
     def test_list_publishers_where_search_by_name_ar_should_filter_results(self) -> None:
@@ -53,7 +53,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("Tafsir Center", body["results"][0]["name"])
 
     def test_list_publishers_where_search_by_description_should_filter_results(self) -> None:
@@ -68,7 +68,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("Tafsir Pub", body["results"][0]["name"])
 
     def test_list_publishers_where_filter_is_verified_true_should_return_only_verified(self) -> None:
@@ -83,7 +83,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("Verified Pub", body["results"][0]["name"])
 
     def test_list_publishers_where_filter_country_should_filter_results(self) -> None:
@@ -98,7 +98,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(1, body["count"])
+        self.assertEqual(1, body["total"])
         self.assertEqual("Saudi Pub", body["results"][0]["name"])
 
     def test_list_publishers_where_page_2_should_return_correct_offset(self) -> None:
@@ -113,7 +113,7 @@ class ListPublishersTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        self.assertEqual(25, body["count"])
+        self.assertEqual(25, body["total"])
         self.assertEqual(5, len(body["results"]))
 
     def test_list_publishers_where_unauthenticated_should_return_401(self) -> None:


### PR DESCRIPTION
## Summary
- Enhanced `NinjaPagination` to return `total`, `page`, `page_size`, `total_pages`, `next_page`, and `prev_page` in all paginated responses
- Added pagination tests for the resources endpoint covering first/middle/last pages and query param preservation
- Updated all existing tests to match the new response schema (`count` -> `total`)

## Changes
- `apps/core/ninja_utils/paginations.py` - Extended `Output` schema with full pagination metadata; added `_build_page_url` and `_build_response` helpers; used `field_validator` for page_size clamping
- `apps/content/tests/internal/test_resources.py` - Added 5 pagination test cases
- 10 test files updated to use `total` instead of `count`

## Test plan
- [ ] Verify `GET /assets?page=2&pageSize=10` returns correct items for that page
- [ ] Verify `total`, `totalPages`, `nextPage`, and `prevPage` are accurate
- [ ] Verify existing pagination behavior on all endpoints is preserved
- [ ] Run full test suite via `uv run pytest`

Closes #135