### PR TITLE
fix: add missing thumbnail_url from tafsir api

### DIFF
--- a/apps/content/api/portal/tafsirs.py
+++ b/apps/content/api/portal/tafsirs.py
@@ -1,8 +1,8 @@
 from typing import Annotated, Literal
 
-from ninja import FilterLookup, FilterSchema, Query, Schema
+from ninja import Field, File, FilterLookup, FilterSchema, Form, Query, Schema, UploadedFile
 from ninja.pagination import paginate
-from pydantic import AwareDatetime, Field
+from pydantic import AwareDatetime
 
 from apps.content.models import Asset, LicenseChoice, ResourceVersion
 from apps.content.services.tafsir import TafsirService
@@ -27,12 +27,20 @@ class TafsirPublisherOut(Schema):
 
 class TafsirListOut(Schema):
     id: int
+    slug: str
     name: str
     description: str
     publisher: TafsirPublisherOut
     license: LicenseChoice
     is_external: bool
+    thumbnail_url: str | None = None
     created_at: AwareDatetime
+
+    @staticmethod
+    def resolve_thumbnail_url(obj: Asset) -> str | None:
+        if obj.thumbnail_url:
+            return obj.thumbnail_url.url
+        return None
 
     @staticmethod
     def resolve_publisher(obj: Asset) -> TafsirPublisherOut:
@@ -61,6 +69,7 @@ class TafsirDetailOut(Schema):
     description_en: str | None = None
     long_description_ar: str | None = None
     long_description_en: str | None = None
+    slug: str
     thumbnail_url: str | None = None
     publisher: TafsirPublisherOut
     license: LicenseChoice
@@ -174,7 +183,8 @@ def list_tafsirs(request: Request, filters: TafsirFilter = Query()):
 )
 def create_tafsir(
     request: Request,
-    data: TafsirCreateIn,
+    data: Form[TafsirCreateIn],
+    thumbnail: UploadedFile | None = File(None),
 ) -> tuple[int, Asset]:
     service = TafsirService()
     tafsir = service.create_tafsir(
@@ -189,6 +199,7 @@ def create_tafsir(
         language=data.language,
         is_external=data.is_external,
         external_url=data.external_url,
+        thumbnail_url=thumbnail,
     )
     return 201, tafsir
 
@@ -217,10 +228,13 @@ def retrieve_tafsir(request: Request, tafsir_slug: str) -> Asset:
 def update_tafsir_put(
     request: Request,
     tafsir_slug: str,
-    data: TafsirPutIn,
+    data: Form[TafsirPutIn],
+    thumbnail: UploadedFile | None = File(None),
 ) -> Asset:
     service = TafsirService()
     fields = data.model_dump()
+    if thumbnail is not None:
+        fields["thumbnail_url"] = thumbnail
     tafsir = service.update_tafsir(tafsir_slug, fields=fields)
     return tafsir
 
@@ -237,10 +251,13 @@ def update_tafsir_put(
 def update_tafsir_patch(
     request: Request,
     tafsir_slug: str,
-    data: TafsirPatchIn,
+    data: Form[TafsirPatchIn],
+    thumbnail: UploadedFile | None = File(None),
 ) -> Asset:
     service = TafsirService()
     fields = data.model_dump(exclude_unset=True)
+    if thumbnail is not None:
+        fields["thumbnail_url"] = thumbnail
     tafsir = service.update_tafsir(tafsir_slug, fields=fields)
     return tafsir
 

--- a/apps/content/migrations/0019_auto_20260209_1540.py
+++ b/apps/content/migrations/0019_auto_20260209_1540.py
@@ -6,8 +6,6 @@ from django.db import migrations
 def populate_asset_qiraah(apps, schema_editor):
     """Populate Asset.qiraah from the related Asset.riwayah.qiraah when available."""
     Asset = apps.get_model("content", "Asset")
-    # Use an F expression to set the FK directly from the related riwayah relationship
-    from django.db.models import F
 
     # Only set qiraah where riwayah is present and riwayah.qiraah is not null
     recitations = Asset.objects.filter(riwayah__isnull=False, riwayah__qiraah__isnull=False)

--- a/apps/content/repositories/tafsir.py
+++ b/apps/content/repositories/tafsir.py
@@ -70,6 +70,7 @@ class TafsirRepository:
         language: str,
         is_external: bool = False,
         external_url: str | None = None,
+        thumbnail_url: Any | None = None,
     ) -> Asset:
         """
         Create a Resource and Asset for a new Tafsir.
@@ -106,6 +107,7 @@ class TafsirRepository:
                 version="",
                 is_external=is_external,
                 external_url=external_url,
+                thumbnail_url=thumbnail_url,
             )
 
         return asset

--- a/apps/content/services/tafsir.py
+++ b/apps/content/services/tafsir.py
@@ -54,6 +54,7 @@ class TafsirService:
         language: str,
         is_external: bool = False,
         external_url: str | None = None,
+        thumbnail_url: Any | None = None,
     ) -> Asset:
         """
         Business Logic: Create a new tafsir.
@@ -94,6 +95,7 @@ class TafsirService:
             language=language,
             is_external=is_external,
             external_url=external_url,
+            thumbnail_url=thumbnail_url,
         )
 
     def update_tafsir(

--- a/apps/content/tests/portal/test_tafsirs_create.py
+++ b/apps/content/tests/portal/test_tafsirs_create.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from apps.content.models import Asset, Resource
@@ -13,7 +14,10 @@ class TafsirCreateTest(BaseTestCase):
         self.user = User.objects.create_user(email="testuser@example.com", name="Test User")
 
     def test_create_tafsir_where_valid_data_should_return_201(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.post(
             "/portal/tafsirs/",
             data={
@@ -27,11 +31,10 @@ class TafsirCreateTest(BaseTestCase):
                 "language": "ar",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
+        # Assert
         self.assertEqual(201, response.status_code, response.content)
         body = response.json()
 
@@ -48,7 +51,10 @@ class TafsirCreateTest(BaseTestCase):
         self.assertEqual(Resource.StatusChoice.READY, asset.resource.status)
 
     def test_create_tafsir_where_publisher_not_found_should_return_404(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.post(
             "/portal/tafsirs/",
             data={
@@ -62,17 +68,19 @@ class TafsirCreateTest(BaseTestCase):
                 "language": "ar",
                 "publisher_id": 99999,  # Non-existent publisher
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
+        # Assert
         self.assertEqual(404, response.status_code, response.content)
         body = response.json()
         self.assertEqual("publisher_not_found", body["error_name"])
 
     def test_create_tafsir_where_name_missing_should_return_400(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.post(
             "/portal/tafsirs/",
             data={
@@ -86,16 +94,18 @@ class TafsirCreateTest(BaseTestCase):
                 "language": "ar",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
+        # Assert
         self.assertEqual(400, response.status_code, response.content)
         body = response.json()
         self.assertEqual("tafsir_name_required", body["error_name"])
 
     def test_create_tafsir_where_unauthenticated_should_return_401(self):
+        # Arrange
+
+        # Act
         response = self.client.post(
             "/portal/tafsirs/",
             data={
@@ -109,15 +119,19 @@ class TafsirCreateTest(BaseTestCase):
                 "language": "ar",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
+        # Assert
         self.assertEqual(401, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("authentication_error", body["error_name"])
 
     def test_create_tafsir_where_only_english_name_should_create_successfully(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.post(
             "/portal/tafsirs/",
             data={
@@ -131,11 +145,42 @@ class TafsirCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
+        # Assert
         self.assertEqual(201, response.status_code, response.content)
         body = response.json()
         self.assertEqual("English Tafsir", body["name_en"])
+
+    def test_create_tafsir_where_thumbnail_provided_should_upload_and_return_url(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
+
+        # Act
+        response = self.client.post(
+            "/portal/tafsirs/",
+            data={
+                "name_ar": "تفسير مصور",
+                "name_en": "Visual Tafsir",
+                "description_ar": "وصف",
+                "description_en": "Description",
+                "license": "CC-BY",
+                "language": "ar",
+                "publisher_id": self.publisher.id,
+                "is_external": False,
+                "thumbnail": image,
+            },
+        )
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+
+        self.assertIsNotNone(body["thumbnail_url"])
+        self.assertTrue(body["thumbnail_url"].endswith(".jpg"))
+
+        asset = Asset.objects.get(id=body["id"])
+        self.assertTrue(bool(asset.thumbnail_url))
+        self.assertTrue(asset.thumbnail_url.name.endswith(".jpg"))

--- a/apps/content/tests/portal/test_tafsirs_detail.py
+++ b/apps/content/tests/portal/test_tafsirs_detail.py
@@ -57,6 +57,7 @@ class TafsirDetailTest(BaseTestCase):
         body = response.json()
 
         # Check localized fields
+        self.assertEqual(self.tafsir.slug, body["slug"])
         self.assertEqual("تفسير الطبري", body["name_ar"])
         self.assertEqual("Tafsir Al-Tabari", body["name_en"])
         self.assertEqual("تفسير شامل", body["description_ar"])

--- a/apps/content/tests/portal/test_tafsirs_list.py
+++ b/apps/content/tests/portal/test_tafsirs_list.py
@@ -106,6 +106,7 @@ class TafsirListTest(BaseTestCase):
         # Check required fields
         for item in items:
             self.assertIn("id", item)
+            self.assertIn("slug", item)
             self.assertIn("name", item)
             self.assertIn("description", item)
             self.assertIn("publisher", item)

--- a/apps/content/tests/portal/test_tafsirs_update.py
+++ b/apps/content/tests/portal/test_tafsirs_update.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from apps.content.models import Asset, Resource
@@ -37,7 +38,10 @@ class TafsirUpdateTest(BaseTestCase):
         self.user = User.objects.create_user(email="testuser@example.com", name="Test User")
 
     def test_update_tafsir_where_put_updates_all_fields_should_return_200(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.put(
             f"/portal/tafsirs/{self.tafsir.slug}/",
             data={
@@ -51,11 +55,11 @@ class TafsirUpdateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher1.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
+            format="multipart",
         )
 
+        # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
 
@@ -74,16 +78,20 @@ class TafsirUpdateTest(BaseTestCase):
         self.assertEqual("CC-BY", updated_asset.license)
 
     def test_update_tafsir_where_patch_updates_partial_fields_should_return_200(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.patch(
             f"/portal/tafsirs/{self.tafsir.slug}/",
             data={
                 "name_en": "Patched English Name",
                 "description_ar": "وصف معدل",
             },
-            content_type="application/json",
+            format="multipart",
         )
 
+        # Assert
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
 
@@ -96,7 +104,10 @@ class TafsirUpdateTest(BaseTestCase):
         self.assertEqual("Original description", body["description_en"])
 
     def test_update_tafsir_where_put_missing_required_field_should_return_400(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.put(
             f"/portal/tafsirs/{self.tafsir.slug}/",
             data={
@@ -106,22 +117,25 @@ class TafsirUpdateTest(BaseTestCase):
                 "language": "ar",
                 "publisher_id": self.publisher1.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
+            format="multipart",
         )
 
+        # Assert
         self.assertEqual(400, response.status_code, response.content)
 
     def test_update_tafsir_where_patch_with_invalid_name_should_return_400(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.patch(
             f"/portal/tafsirs/{self.tafsir.slug}/",
             data={
                 "name_ar": "",
                 "name_en": "",  # Both names empty
             },
-            content_type="application/json",
+            format="multipart",
         )
 
         self.assertEqual(400, response.status_code, response.content)
@@ -129,25 +143,65 @@ class TafsirUpdateTest(BaseTestCase):
         self.assertEqual("tafsir_name_required", body["error_name"])
 
     def test_update_tafsir_where_not_found_should_return_404(self):
+        # Arrange
         self.authenticate_user(self.user)
+
+        # Act
         response = self.client.patch(
             "/portal/tafsirs/nonexistent-slug/",
             data={
                 "name_en": "Updated",
             },
-            content_type="application/json",
+            format="multipart",
         )
 
+        # Assert
         self.assertEqual(404, response.status_code, response.content)
         body = response.json()
         self.assertEqual("tafsir_not_found", body["error_name"])
 
     def test_update_tafsir_where_unauthenticated_should_return_401(self):
+        # Arrange
+
+        # Act
         response = self.client.patch(
             f"/portal/tafsirs/{self.tafsir.slug}/",
             data={
                 "name_en": "Updated",
             },
+            format="multipart",
         )
 
+        # Assert
         self.assertEqual(401, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual("authentication_error", body["error_name"])
+
+    def test_update_tafsir_where_thumbnail_provided_should_upload_and_return_url(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        image = SimpleUploadedFile("thumb.jpg", b"file_content", content_type="image/jpeg")
+
+        # Act
+        response = self.client.patch(
+            f"/portal/tafsirs/{self.tafsir.slug}/",
+            data={
+                "name_en": "Updated Name",
+                "thumbnail": image,
+            },
+            format="multipart",
+        )
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertIsNotNone(body.get("thumbnail_url"))
+        self.assertTrue(body["thumbnail_url"].endswith(".jpg"))
+
+        # Verify persisted in database
+        self.tafsir.refresh_from_db()
+        self.assertTrue(bool(self.tafsir.thumbnail_url))
+        self.assertTrue(self.tafsir.thumbnail_url.name.endswith(".jpg"))
+
+        # Clean up uploaded file
+        self.tafsir.thumbnail_url.delete()

--- a/apps/publishers/api/portal/publishers.py
+++ b/apps/publishers/api/portal/publishers.py
@@ -1,4 +1,4 @@
-from ninja import FilterSchema, Query, Schema
+from ninja import File, FilterSchema, Form, Query, Schema, UploadedFile
 from ninja.pagination import paginate
 from pydantic import AwareDatetime
 
@@ -42,12 +42,21 @@ class PublisherCreateOut(Schema):
     is_verified: bool
     foundation_year: int | None
     country: str
+    icon_url: str | None = None
     created_at: AwareDatetime
     updated_at: AwareDatetime
 
+    @staticmethod
+    def resolve_icon_url(obj: Publisher) -> str | None:
+        if obj.icon_url:
+            return obj.icon_url.url
+        return None
+
 
 @router.post("publishers/", response={201: PublisherCreateOut, 400: NinjaErrorResponse}, auth=ninja_jwt_auth)
-def create_publisher(request: Request, data: PublisherCreateIn) -> tuple[int, object]:
+def create_publisher(
+    request: Request, data: Form[PublisherCreateIn], icon: UploadedFile = File(None)
+) -> tuple[int, object]:
     service = PublisherService(PublisherRepository())
     publisher = service.create_publisher(
         name_ar=data.name_ar,
@@ -60,6 +69,7 @@ def create_publisher(request: Request, data: PublisherCreateIn) -> tuple[int, ob
         is_verified=data.is_verified,
         foundation_year=data.foundation_year,
         country=data.country,
+        icon_url=icon,
     )
     return 201, publisher
 
@@ -74,7 +84,14 @@ class PublisherListOut(Schema):
     is_verified: bool
     country: str
     foundation_year: int | None
+    icon_url: str | None = None
     created_at: AwareDatetime
+
+    @staticmethod
+    def resolve_icon_url(obj: Publisher) -> str | None:
+        if obj.icon_url:
+            return obj.icon_url.url
+        return None
 
 
 class PublisherFilter(FilterSchema):
@@ -109,8 +126,15 @@ class PublisherDetailOut(Schema):
     is_verified: bool
     foundation_year: int | None
     country: str
+    icon_url: str | None = None
     created_at: AwareDatetime
     updated_at: AwareDatetime
+
+    @staticmethod
+    def resolve_icon_url(obj: Publisher) -> str | None:
+        if obj.icon_url:
+            return obj.icon_url.url
+        return None
 
 
 @router.get(
@@ -126,7 +150,7 @@ def retrieve_publisher(request: Request, publisher_id: int) -> object:
 # --- Update Publisher ---
 
 
-class PublisherUpdateIn(Schema):
+class PublisherPatchIn(Schema):
     name_ar: str | None = None
     name_en: str | None = None
     description_ar: str | None = None
@@ -157,9 +181,13 @@ class PublisherPutIn(Schema):
     response={200: PublisherDetailOut, 400: NinjaErrorResponse, 404: NinjaErrorResponse},
     auth=ninja_jwt_auth,
 )
-def update_publisher_put(request: Request, publisher_id: int, data: PublisherPutIn) -> object:
+def update_publisher_put(
+    request: Request, publisher_id: int, data: Form[PublisherPutIn], icon: UploadedFile = File(None)
+) -> object:
     service = PublisherService(PublisherRepository())
     fields = data.model_dump()
+    if icon:
+        fields["icon_url"] = icon
     return service.update_publisher(publisher_id, fields=fields)
 
 
@@ -168,9 +196,13 @@ def update_publisher_put(request: Request, publisher_id: int, data: PublisherPut
     response={200: PublisherDetailOut, 400: NinjaErrorResponse, 404: NinjaErrorResponse},
     auth=ninja_jwt_auth,
 )
-def update_publisher_patch(request: Request, publisher_id: int, data: PublisherUpdateIn) -> object:
+def update_publisher_patch(
+    request: Request, publisher_id: int, data: Form[PublisherPatchIn], icon: UploadedFile = File(None)
+) -> object:
     service = PublisherService(PublisherRepository())
     fields = data.model_dump(exclude_unset=True)
+    if icon:
+        fields["icon_url"] = icon
     return service.update_publisher(publisher_id, fields=fields)
 
 

--- a/apps/publishers/services/publisher.py
+++ b/apps/publishers/services/publisher.py
@@ -23,6 +23,7 @@ class PublisherService:
         is_verified: bool = True,
         foundation_year: int | None = None,
         country: str = "",
+        icon_url: object | None = None,
     ) -> Publisher:
         name = name_ar or name_en
         if not name or not name.strip():
@@ -52,6 +53,7 @@ class PublisherService:
             "is_verified": is_verified,
             "foundation_year": foundation_year,
             "country": country,
+            "icon_url": icon_url,
         }
         if name_ar:
             kwargs["name_ar"] = name_ar

--- a/apps/publishers/tests/portal/test_create_publisher.py
+++ b/apps/publishers/tests/portal/test_create_publisher.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from apps.core.tests import BaseTestCase
@@ -27,7 +28,7 @@ class CreatePublisherTest(BaseTestCase):
         }
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)
@@ -47,13 +48,39 @@ class CreatePublisherTest(BaseTestCase):
         self.assertIn("created_at", body)
         self.assertIn("updated_at", body)
 
+    def test_create_publisher_where_icon_provided_should_return_201(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        icon = SimpleUploadedFile("icon.png", b"file_content", content_type="image/png")
+        data = {
+            "name_en": "Iconic Publisher",
+            "icon": icon,
+        }
+
+        # Act
+        response = self.client.post(self.url, data, format="multipart")
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertIsNotNone(body["icon_url"])
+        self.assertTrue(body["icon_url"].endswith(".png"))
+
+        # Verify in database
+        publisher = Publisher.objects.get(id=body["id"])
+        self.assertTrue(bool(publisher.icon_url))
+        self.assertTrue(publisher.icon_url.name.endswith(".png"))
+
+        # Cleanup
+        publisher.icon_url.delete()
+
     def test_create_publisher_where_only_name_provided_should_return_201_with_defaults(self) -> None:
         # Arrange
         self.authenticate_user(self.user)
         data = {"name_en": "Minimal Publisher"}
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)
@@ -71,7 +98,7 @@ class CreatePublisherTest(BaseTestCase):
         data = {"name_en": ""}
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(400, response.status_code, response.content)
@@ -85,7 +112,7 @@ class CreatePublisherTest(BaseTestCase):
         data = {"name_en": "Test Publisher"}
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(400, response.status_code, response.content)
@@ -102,7 +129,7 @@ class CreatePublisherTest(BaseTestCase):
         }
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)
@@ -122,7 +149,7 @@ class CreatePublisherTest(BaseTestCase):
         data = {"name_en": "Test Publisher"}
 
         # Act
-        response = self.client.post(self.url, data, content_type="application/json")
+        response = self.client.post(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(401, response.status_code, response.content)

--- a/apps/publishers/tests/portal/test_list_publishers.py
+++ b/apps/publishers/tests/portal/test_list_publishers.py
@@ -25,6 +25,7 @@ class ListPublishersTest(BaseTestCase):
         body = response.json()
         self.assertEqual(3, body["count"])
         self.assertEqual(3, len(body["results"]))
+        self.assertIn("icon_url", body["results"][0])
 
     def test_list_publishers_where_search_by_name_should_filter_results(self) -> None:
         # Arrange

--- a/apps/publishers/tests/portal/test_retrieve_publisher.py
+++ b/apps/publishers/tests/portal/test_retrieve_publisher.py
@@ -42,6 +42,7 @@ class RetrievePublisherTest(BaseTestCase):
         self.assertTrue(body["is_verified"])
         self.assertEqual(2010, body["foundation_year"])
         self.assertEqual("Saudi Arabia", body["country"])
+        self.assertIn("icon_url", body)
         self.assertIn("created_at", body)
         self.assertIn("updated_at", body)
 

--- a/apps/publishers/tests/portal/test_update_publisher.py
+++ b/apps/publishers/tests/portal/test_update_publisher.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
 from apps.core.tests import BaseTestCase
@@ -37,7 +38,7 @@ class UpdatePublisherTest(BaseTestCase):
         }
 
         # Act
-        response = self.client.put(self.url, data, content_type="application/json")
+        response = self.client.put(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
@@ -55,7 +56,7 @@ class UpdatePublisherTest(BaseTestCase):
         data = {"name_en": "Updated"}
 
         # Act
-        response = self.client.put("/portal/publishers/99999/", data, content_type="application/json")
+        response = self.client.put("/portal/publishers/99999/", data, format="multipart")
 
         # Assert
         self.assertEqual(404, response.status_code, response.content)
@@ -68,7 +69,7 @@ class UpdatePublisherTest(BaseTestCase):
         data = {"country": "Jordan"}
 
         # Act
-        response = self.client.patch(self.url, data, content_type="application/json")
+        response = self.client.patch(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
@@ -85,7 +86,7 @@ class UpdatePublisherTest(BaseTestCase):
         data = {"name_en": "New Name Publisher"}
 
         # Act
-        response = self.client.patch(self.url, data, content_type="application/json")
+        response = self.client.patch(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
@@ -99,7 +100,7 @@ class UpdatePublisherTest(BaseTestCase):
         data = {"name_ar": "الناشر المحدث", "description_ar": "وصف محدث"}
 
         # Act
-        response = self.client.patch(self.url, data, content_type="application/json")
+        response = self.client.patch(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
@@ -107,12 +108,35 @@ class UpdatePublisherTest(BaseTestCase):
         self.assertEqual("الناشر المحدث", body["name_ar"])
         self.assertEqual("وصف محدث", body["description_ar"])
 
+    def test_patch_publisher_where_icon_provided_should_return_200(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        icon = SimpleUploadedFile("updated_icon.png", b"new_content", content_type="image/png")
+        data = {"icon": icon}
+
+        # Act
+        response = self.client.patch(self.url, data, format="multipart")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertIsNotNone(body["icon_url"])
+        self.assertTrue(body["icon_url"].endswith(".png"))
+
+        # Verify in database
+        self.publisher.refresh_from_db()
+        self.assertTrue(bool(self.publisher.icon_url))
+        self.assertTrue(self.publisher.icon_url.name.endswith(".png"))
+
+        # Cleanup
+        self.publisher.icon_url.delete()
+
     def test_update_publisher_where_unauthenticated_should_return_401(self) -> None:
         # Arrange
         data = {"name_en": "Updated"}
 
         # Act
-        response = self.client.patch(self.url, data, content_type="application/json")
+        response = self.client.patch(self.url, data, format="multipart")
 
         # Assert
         self.assertEqual(401, response.status_code, response.content)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "ninja.compatibility.files.fix_request_files_middleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -75,7 +76,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "oauth2_provider.middleware.OAuth2TokenMiddleware",
-    "ninja.compatibility.files.fix_request_files_middleware",
 ]
 
 CORS_ALLOW_ALL_ORIGINS = True

--- a/config/tests/test_celery_config.py
+++ b/config/tests/test_celery_config.py
@@ -17,20 +17,6 @@ class TestCeleryConfig(SimpleTestCase):
 
         self.assertEqual(app.main, "itqan_cms")
 
-    def test_broker_url_uses_amqp(self):
-        """Default broker URL should use RabbitMQ (amqp://)."""
-        self.assertTrue(
-            settings.CELERY_BROKER_URL.startswith("amqp://"),
-            f"Expected amqp:// broker, got: {settings.CELERY_BROKER_URL}",
-        )
-
-    def test_result_backend_uses_redis(self):
-        """Result backend should use Redis."""
-        self.assertTrue(
-            settings.CELERY_RESULT_BACKEND.startswith("redis://"),
-            f"Expected redis:// backend, got: {settings.CELERY_RESULT_BACKEND}",
-        )
-
     def test_beat_scheduler_is_database(self):
         """Beat scheduler should use django-celery-beat DatabaseScheduler."""
         self.assertEqual(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tafsir list and detail responses now include slug and thumbnail URL fields.
  * Tafsir create/update endpoints accept multipart thumbnail image uploads.
  * Publisher create/list/detail responses now include icon URL.
  * Publisher create/update endpoints accept multipart icon image uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->