### PR TITLE
Setup sandbox email settings for staging

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,6 +173,12 @@ jobs:
                 echo "MIXPANEL_SERVICE_SECRET=${{ secrets.MIXPANEL_SERVICE_SECRET }}";
                 echo "MIXPANEL_INGEST_HOST=${{ secrets.MIXPANEL_INGEST_HOST }}";
                 echo "MIXPANEL_API_BASE=${{ secrets.MIXPANEL_API_BASE }}";
+                echo "STAGING_EMAIL_HOST=${{ secrets.STAGING_EMAIL_HOST }}";
+                echo "STAGING_EMAIL_PORT=${{ secrets.STAGING_EMAIL_PORT }}";
+                echo "STAGING_EMAIL_HOST_USER=${{ secrets.STAGING_EMAIL_HOST_USER }}";
+                echo "STAGINgG_EMAIL_HOST_PASSWORD=${{ secrets.STAGING_EMAIL_HOST_PASSWORD }}";
+                echo "STAGING_EMAIL_SENDER_NAME=${{ secrets.STAGING_EMAIL_SENDER_NAME }}";
+                echo "STAGING_EMAIL_SENDER_EMAIL=${{ secrets.STAGING_EMAIL_SENDER_EMAIL }}";
               } > deployment/docker/.env
             elif [ "${{ env.ENV_NAME }}" = "production" ]; then
               {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,7 +176,7 @@ jobs:
                 echo "STAGING_EMAIL_HOST=${{ secrets.STAGING_EMAIL_HOST }}";
                 echo "STAGING_EMAIL_PORT=${{ secrets.STAGING_EMAIL_PORT }}";
                 echo "STAGING_EMAIL_HOST_USER=${{ secrets.STAGING_EMAIL_HOST_USER }}";
-                echo "STAGINgG_EMAIL_HOST_PASSWORD=${{ secrets.STAGING_EMAIL_HOST_PASSWORD }}";
+                echo "STAGING_EMAIL_HOST_PASSWORD=${{ secrets.STAGING_EMAIL_HOST_PASSWORD }}";
                 echo "STAGING_EMAIL_SENDER_NAME=${{ secrets.STAGING_EMAIL_SENDER_NAME }}";
                 echo "STAGING_EMAIL_SENDER_EMAIL=${{ secrets.STAGING_EMAIL_SENDER_EMAIL }}";
               } > deployment/docker/.env

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -299,9 +299,6 @@ CELERY_WORKER_SEND_TASK_EVENTS = True
 CELERY_TASK_SEND_SENT_EVENT = True
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
-# Email server
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
 # Site ID (required for allauth)
 SITE_ID = 1
 

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -88,6 +88,11 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 # =========================
+# Email (console)
+# =========================
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# =========================
 # Debug Toolbar (optional)
 # =========================
 if importlib.util.find_spec("debug_toolbar"):

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -149,6 +149,22 @@ settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
 }
 
 # ============================================================
+# Email (sandbox)
+# ============================================================
+
+_EMAIL_SENDER_NAME: str = config("STAGING_EMAIL_SENDER_NAME", default="")
+_EMAIL_SENDER_EMAIL: str = config("STAGING_EMAIL_SENDER_EMAIL", default="")
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = config("STAGING_EMAIL_HOST", default="")
+EMAIL_PORT = config("STAGING_EMAIL_PORT", cast=int, default=587)
+EMAIL_HOST_USER = config("STAGING_EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = config("STAGING_EMAIL_HOST_PASSWORD", default="")
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
+DEFAULT_FROM_EMAIL = f"{_EMAIL_SENDER_NAME} <{_EMAIL_SENDER_EMAIL}>" if _EMAIL_SENDER_NAME else _EMAIL_SENDER_EMAIL
+
+# ============================================================
 # Feature flags
 # ============================================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized email configuration across development, staging, and production environments.
  * Development environment uses console-based email output for local testing without external transmission.
  * Staging environment configured with SMTP email delivery using environment-specific credentials.
  * Updated CI/CD pipeline to handle staging-specific email configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->