### PR TITLE
Clean up bad patterns in mixpanel implementation

### DIFF
--- a/apps/content/services/usage.py
+++ b/apps/content/services/usage.py
@@ -60,42 +60,20 @@ def log_api_access(user, *, api_endpoint="", ip_address=None, user_agent="", ass
 
 def log_asset_download(user, asset, ip_address=None, user_agent=""):
     """Track asset download event with async processing"""
+    from .tasks import track_event_async
 
-    try:
-        from .tasks import track_event_async
-
-        event_data = {
-            "developer_user_id": user.id,
-            "usage_kind": "file_download",
-            "asset_id": asset.id,
-            "metadata": {
-                "asset_title": asset.title,
-                "file_size": asset.file_size,
-                "format": asset.format,
-                "category": asset.category,
-            },
-            "ip_address": ip_address,
-            "user_agent": user_agent,
-        }
-        if track_event_async(event_data):
-            logger.debug(f"Asset download event queued async [user_id={user.id}, asset_id={asset.id}]")
-            return None  # Event queued for async processing
-    except ImportError:
-        logger.warning(
-            f"track_event_async not available — falling back to sync usage event [user_id={user.id}, asset_id={asset.id}]"
-        )
-
-    # Fallback to synchronous creation
-    return UsageEvent.objects.create(
-        developer_user=user,
-        usage_kind="file_download",
-        asset_id=asset.id,
-        metadata={
+    event_data = {
+        "developer_user_id": user.id,
+        "usage_kind": "file_download",
+        "asset_id": asset.id,
+        "metadata": {
             "asset_title": asset.title,
             "file_size": asset.file_size,
             "format": asset.format,
             "category": asset.category,
         },
-        ip_address=ip_address,
-        user_agent=user_agent,
-    )
+        "ip_address": ip_address,
+        "user_agent": user_agent,
+    }
+    track_event_async(event_data)
+    return None

--- a/apps/content/services/usage.py
+++ b/apps/content/services/usage.py
@@ -62,7 +62,7 @@ def log_asset_download(user, asset, ip_address=None, user_agent=""):
     """Track asset download event with async processing"""
     from .tasks import create_usage_event_task
 
-    create_usage_event_task.delay({
+    event_data = {
         "developer_user_id": user.id,
         "usage_kind": "file_download",
         "asset_id": asset.id,
@@ -74,5 +74,6 @@ def log_asset_download(user, asset, ip_address=None, user_agent=""):
         },
         "ip_address": ip_address,
         "user_agent": user_agent,
-    })
+    }
+    create_usage_event_task.delay(event_data)
     return None

--- a/apps/content/services/usage.py
+++ b/apps/content/services/usage.py
@@ -60,9 +60,9 @@ def log_api_access(user, *, api_endpoint="", ip_address=None, user_agent="", ass
 
 def log_asset_download(user, asset, ip_address=None, user_agent=""):
     """Track asset download event with async processing"""
-    from .tasks import track_event_async
+    from .tasks import create_usage_event_task
 
-    event_data = {
+    create_usage_event_task.delay({
         "developer_user_id": user.id,
         "usage_kind": "file_download",
         "asset_id": asset.id,
@@ -74,6 +74,5 @@ def log_asset_download(user, asset, ip_address=None, user_agent=""):
         },
         "ip_address": ip_address,
         "user_agent": user_agent,
-    }
-    track_event_async(event_data)
+    })
     return None

--- a/apps/content/tasks.py
+++ b/apps/content/tasks.py
@@ -94,27 +94,13 @@ def create_usage_event_task(self, event_data):
 
 
 def track_event_async(event_data):
-    """
-    Helper function to queue usage event tracking
-
-    Args:
-        event_data: Event data dictionary
-    """
+    """Queue a usage event for async processing via Celery."""
     try:
-        # Queue the task for async processing
         create_usage_event_task.delay(event_data)
         return True
     except Exception as e:
         logger.error(f"Failed to queue usage event: {e}")
-        # Fallback to synchronous creation if Celery is unavailable
-        try:
-            from .models import UsageEvent
-
-            UsageEvent.objects.create(**event_data)
-            return True
-        except Exception as sync_e:
-            logger.error(f"Failed to create usage event synchronously: {sync_e}")
-            return False
+        return False
 
 
 @shared_task

--- a/apps/content/tasks.py
+++ b/apps/content/tasks.py
@@ -93,16 +93,6 @@ def create_usage_event_task(self, event_data):
         raise self.retry(exc=exc, countdown=60 * (self.request.retries + 1)) from exc
 
 
-def track_event_async(event_data):
-    """Queue a usage event for async processing via Celery."""
-    try:
-        create_usage_event_task.delay(event_data)
-        return True
-    except Exception as e:
-        logger.error(f"Failed to queue usage event: {e}")
-        return False
-
-
 @shared_task
 def cleanup_stuck_multipart_uploads_task(older_than_hours: int = 2):
     """

--- a/apps/usage_tracking/middlewares/usage_tracking_middleware.py
+++ b/apps/usage_tracking/middlewares/usage_tracking_middleware.py
@@ -55,8 +55,6 @@ class UsageTrackingMiddleware:
         entity_ids = extract_entity_ids(self._response_body(response))
 
         properties = {
-            "method": request.method,
-            "path": request.path,
             "endpoint": f"{request.method} {request.path}",
             "status_code": response.status_code,
             "latency_ms": latency_ms,

--- a/apps/usage_tracking/services/publisher_resolver.py
+++ b/apps/usage_tracking/services/publisher_resolver.py
@@ -1,4 +1,4 @@
-"""Resolve a request's publisher identity from its OAuth2 token.
+"""Resolve a request's publisher identity from the authenticated user.
 
 Used by the usage tracking middleware to tag each public API event with the
 publisher that owns the OAuth2 application the consumer is using.
@@ -17,10 +17,8 @@ def resolve_publisher_from_request(request) -> tuple[int | None, str | None]:
 
     Resolution order:
       1. In-request memo (avoids duplicate calls within the same request)
-      2. Redis cache keyed by access_token.pk (avoids repeated DB lookups)
-      3. DB lookup via access_token → application → owner → PublisherMember
-
-    ``request.access_token`` must be set by OAuth2Auth before this is called.
+      2. Redis cache keyed by user.pk (avoids repeated DB lookups)
+      3. DB lookup via request.user → PublisherMember
     """
     cached = getattr(request, _CACHE_ATTR, None)
     if cached is not None:
@@ -35,28 +33,20 @@ def resolve_publisher_from_request(request) -> tuple[int | None, str | None]:
 
 
 def _resolve(request) -> tuple[int | None, str | None]:
-    token = getattr(request, "access_token", None)
-    if token is None:
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
         return None, None
 
-    token_pk = getattr(token, "pk", None)
-    if token_pk is not None:
-        redis_key = f"pub_resolver:token:{token_pk}"
+    user_pk = getattr(user, "pk", None)
+    if user_pk is not None:
+        redis_key = f"pub_resolver:user:{user_pk}"
         cached = cache.get(redis_key)
         if cached is not None:
             return tuple(cached)
 
-    application = getattr(token, "application", None)
-    if application is None:
-        return None, None
+    result = _lookup_publisher_for_user(user)
 
-    owner = getattr(application, "user", None)
-    if owner is None:
-        return None, None
-
-    result = _lookup_publisher_for_user(owner)
-
-    if token_pk is not None:
+    if user_pk is not None:
         cache.set(redis_key, list(result), _REDIS_CACHE_TTL)
 
     return result

--- a/apps/usage_tracking/tests/test_middleware.py
+++ b/apps/usage_tracking/tests/test_middleware.py
@@ -38,8 +38,7 @@ class TestUsageTrackingMiddleware:
         props = kwargs["properties"]
         assert props["publisher_id"] == 42
         assert props["publisher_slug"] == "acme"
-        assert props["method"] == "GET"
-        assert props["path"] == "/reciters"
+        assert props["endpoint"] == "GET /reciters"
         assert props["status_code"] == 200
         assert "latency_ms" in props
         assert props["entity_ids"] == [1, 2]

--- a/apps/usage_tracking/tests/test_publisher_resolver.py
+++ b/apps/usage_tracking/tests/test_publisher_resolver.py
@@ -2,12 +2,23 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
 
 from apps.usage_tracking.services.publisher_resolver import resolve_publisher_from_request
 
 
 class TestPublisherResolver:
-    def test_resolve_no_access_token_attr_returns_none(self):
+    def setup_method(self):
+        cache.clear()
+    def test_resolve_no_user_attr_returns_none(self):
+        request = SimpleNamespace()
+
+        publisher_id, slug = resolve_publisher_from_request(request)
+
+        assert publisher_id is None
+        assert slug is None
+
+    def test_resolve_anonymous_user_returns_none(self):
         request = SimpleNamespace(user=AnonymousUser())
 
         publisher_id, slug = resolve_publisher_from_request(request)
@@ -15,63 +26,40 @@ class TestPublisherResolver:
         assert publisher_id is None
         assert slug is None
 
-    def test_resolve_none_token_returns_none(self):
-        request = SimpleNamespace(access_token=None, user=AnonymousUser())
-
-        publisher_id, slug = resolve_publisher_from_request(request)
-
-        assert publisher_id is None
-        assert slug is None
-
-    def test_resolve_token_without_application_returns_none(self):
-        token = SimpleNamespace(application=None)
-        request = SimpleNamespace(access_token=token, user=AnonymousUser())
-
-        publisher_id, slug = resolve_publisher_from_request(request)
-
-        assert publisher_id is None
-        assert slug is None
-
-    def test_resolve_application_without_owner_returns_none(self):
-        token = SimpleNamespace(application=SimpleNamespace(user=None))
-        request = SimpleNamespace(access_token=token, user=AnonymousUser())
-
-        publisher_id, slug = resolve_publisher_from_request(request)
-
-        assert publisher_id is None
-        assert slug is None
-
+    @patch("apps.usage_tracking.services.publisher_resolver.cache")
     @patch("apps.usage_tracking.services.publisher_resolver._lookup_publisher_for_user")
-    def test_resolve_app_owner_has_no_publisher_returns_none(self, mock_lookup):
+    def test_resolve_authenticated_user_with_no_publisher_returns_none(self, mock_lookup, mock_cache):
+        mock_cache.get.return_value = None
         mock_lookup.return_value = (None, None)
-        owner = MagicMock(name="owner")
-        token = SimpleNamespace(application=SimpleNamespace(user=owner))
-        request = SimpleNamespace(access_token=token, user=owner)
+        user = SimpleNamespace(is_authenticated=True, pk=1)
+        request = SimpleNamespace(user=user)
 
         publisher_id, slug = resolve_publisher_from_request(request)
 
         assert publisher_id is None
         assert slug is None
-        mock_lookup.assert_called_once_with(owner)
+        mock_lookup.assert_called_once_with(user)
 
+    @patch("apps.usage_tracking.services.publisher_resolver.cache")
     @patch("apps.usage_tracking.services.publisher_resolver._lookup_publisher_for_user")
-    def test_resolve_valid_token_returns_publisher(self, mock_lookup):
+    def test_resolve_authenticated_user_returns_publisher(self, mock_lookup, mock_cache):
+        mock_cache.get.return_value = None
         mock_lookup.return_value = (42, "acme-publisher")
-        owner = MagicMock(name="owner")
-        token = SimpleNamespace(application=SimpleNamespace(user=owner))
-        request = SimpleNamespace(access_token=token, user=owner)
+        user = SimpleNamespace(is_authenticated=True, pk=2)
+        request = SimpleNamespace(user=user)
 
         publisher_id, slug = resolve_publisher_from_request(request)
 
         assert publisher_id == 42
         assert slug == "acme-publisher"
 
+    @patch("apps.usage_tracking.services.publisher_resolver.cache")
     @patch("apps.usage_tracking.services.publisher_resolver._lookup_publisher_for_user")
-    def test_resolve_caches_per_request(self, mock_lookup):
+    def test_resolve_caches_per_request(self, mock_lookup, mock_cache):
+        mock_cache.get.return_value = None
         mock_lookup.return_value = (42, "acme")
-        owner = MagicMock(name="owner")
-        token = SimpleNamespace(application=SimpleNamespace(user=owner))
-        request = SimpleNamespace(access_token=token, user=owner)
+        user = SimpleNamespace(is_authenticated=True, pk=3)
+        request = SimpleNamespace(user=user)
 
         resolve_publisher_from_request(request)
         resolve_publisher_from_request(request)

--- a/apps/usage_tracking/tests/test_publisher_resolver.py
+++ b/apps/usage_tracking/tests/test_publisher_resolver.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
@@ -10,6 +10,7 @@ from apps.usage_tracking.services.publisher_resolver import resolve_publisher_fr
 class TestPublisherResolver:
     def setup_method(self):
         cache.clear()
+
     def test_resolve_no_user_attr_returns_none(self):
         request = SimpleNamespace()
 


### PR DESCRIPTION
## Summary

- **publisher_resolver**: resolve via `request.user` directly instead of `token → application → user` chain; cache by `user.pk` (one entry per user instead of per token)
- **usage_tracking_middleware**: drop redundant `method` and `path` properties — `endpoint` is already `method + path`
- **content/services/usage**: remove impossible `ImportError` guard and dead sync fallback in `log_asset_download`
- **content/tasks**: remove broken `UsageEvent.objects.create(**event_data)` fallback in `track_event_async` (wrong field name, unreachable)

## Test plan

- [ ] All usage_tracking unit tests pass (`test_publisher_resolver`, `test_middleware`, `test_mixpanel_client`, `test_tasks`, `test_entity_extractor`, `test_usage_queries`)
- [ ] Verify Mixpanel events in staging still fire with `endpoint` property after deploy
- [ ] Verify publisher tagging still works on public API requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Usage events are now consistently enqueued asynchronously for more reliable tracking.
  * Publisher resolution now derives identity from the authenticated request user.
  * API request tracking metadata consolidated into a single endpoint field (method + path).

* **Tests**
  * Updated tests to match tracking, resolution, and caching behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->