### PR TITLE
Fix OAuth2 client_credentials publisher attribution

### DIFF
--- a/apps/core/ninja_utils/auth.py
+++ b/apps/core/ninja_utils/auth.py
@@ -30,6 +30,7 @@ class OAuth2Auth(OAuth2Authentication):
         if res is None:
             return None
         request.user = res[0]
+        request.access_token = res[1]
         return res
 
 

--- a/apps/usage_tracking/services/publisher_resolver.py
+++ b/apps/usage_tracking/services/publisher_resolver.py
@@ -23,23 +23,43 @@ def resolve_publisher_from_request(request) -> tuple[int | None, str | None, str
 
 
 def _resolve(request) -> tuple[int | None, str | None, str | None]:
-    user = getattr(request, "user", None)
-    if user is None or not getattr(user, "is_authenticated", False):
+    owner = _resolve_owner(request)
+    if owner is None:
         return None, None, None
 
-    user_pk = getattr(user, "pk", None)
+    user_pk = getattr(owner, "pk", None)
     if user_pk is not None:
         redis_key = f"pub_resolver:user:{user_pk}"
         cached = cache.get(redis_key)
         if cached is not None:
             return cached
 
-    result = _lookup_publisher_for_user(user)
+    result = _lookup_publisher_for_user(owner)
 
     if user_pk is not None:
         cache.set(redis_key, result, _REDIS_CACHE_TTL)
 
     return result
+
+
+def _resolve_owner(request):
+    """Return the user whose publisher membership we should look up.
+
+    Prefers an authenticated request.user (JWT/session). Falls back to the
+    OAuth2 application owner so client_credentials tokens (which have no
+    resource owner) still resolve to a publisher.
+    """
+    user = getattr(request, "user", None)
+    if user is not None and getattr(user, "is_authenticated", False):
+        return user
+
+    token = getattr(request, "access_token", None)
+    if token is None:
+        return None
+    application = getattr(token, "application", None)
+    if application is None:
+        return None
+    return getattr(application, "user", None)
 
 
 def _lookup_publisher_for_user(owner) -> tuple[int | None, str | None, str | None]:

--- a/apps/usage_tracking/tests/test_publisher_resolver.py
+++ b/apps/usage_tracking/tests/test_publisher_resolver.py
@@ -86,3 +86,40 @@ class TestPublisherResolver:
         stored = mock_cache.set.call_args[0][1]
         assert isinstance(stored, tuple)
         assert result == (42, "acme", "Acme Publisher")
+
+    @patch("apps.usage_tracking.services.publisher_resolver.cache")
+    @patch("apps.usage_tracking.services.publisher_resolver._lookup_publisher_for_user")
+    def test_resolve_oauth2_client_credentials_falls_back_to_app_owner(self, mock_lookup, mock_cache):
+        """For OAuth2 client_credentials grant, request.user is anonymous but
+        access_token.application.user is the app owner — fall back to that."""
+        mock_cache.get.return_value = None
+        mock_lookup.return_value = (1, "scqr", "Saudi Center for Quranic Recitations")
+        app_owner = SimpleNamespace(is_authenticated=True, pk=99)
+        token = SimpleNamespace(application=SimpleNamespace(user=app_owner))
+        request = SimpleNamespace(user=AnonymousUser(), access_token=token)
+
+        publisher_id, slug, name = resolve_publisher_from_request(request)
+
+        assert publisher_id == 1
+        assert slug == "scqr"
+        assert name == "Saudi Center for Quranic Recitations"
+        mock_lookup.assert_called_once_with(app_owner)
+
+    def test_resolve_no_user_no_token_returns_none(self):
+        request = SimpleNamespace(user=AnonymousUser())
+
+        publisher_id, slug, name = resolve_publisher_from_request(request)
+
+        assert publisher_id is None
+        assert slug is None
+        assert name is None
+
+    def test_resolve_token_without_application_returns_none(self):
+        token = SimpleNamespace(application=None)
+        request = SimpleNamespace(user=AnonymousUser(), access_token=token)
+
+        publisher_id, slug, name = resolve_publisher_from_request(request)
+
+        assert publisher_id is None
+        assert slug is None
+        assert name is None


### PR DESCRIPTION
## Summary
OAuth2 \`client_credentials\` tokens have no resource owner, so \`request.user\` is anonymous and \`publisher_resolver\` returned \`(None, None, None)\` for every public API consumer call.

## Why this matters
Public API is consumed by downstream publisher apps via OAuth2 \`client_credentials\`. Without this fix, every event has \`publisher_id=null\` — per-publisher analytics impossible.

## Changes
- \`OAuth2Auth\`: stash \`request.access_token\` alongside \`request.user\`
- \`publisher_resolver\`: extract \`_resolve_owner()\` that prefers authenticated \`request.user\` and falls back to \`access_token.application.user\`
- Tests: 3 new — client_credentials fallback, no token + anonymous, token without application

## Test plan
- [x] Unit tests green (9 passed)
- [ ] CI green
- [ ] After staging deploy: hit public API via OAuth2 client_credentials, verify Mixpanel events have \`publisher_id\` populated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 access tokens are now accessible on requests during authentication.
  * Publisher resolution now supports client-credentials OAuth2 flow as a fallback when a resource owner is unavailable.

* **Tests**
  * Added test coverage for publisher resolution with OAuth2 client credentials and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->