### PR TITLE
Harden usage tracking: stable distinct_id, app identity, geo, errors, parsed filters

### DIFF
--- a/apps/usage_tracking/middlewares/usage_tracking_middleware.py
+++ b/apps/usage_tracking/middlewares/usage_tracking_middleware.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import time
 import uuid
+from urllib.parse import parse_qs
 
 from apps.usage_tracking.services.entity_extractor import extract_entities
 from apps.usage_tracking.services.publisher_resolver import resolve_publisher_from_request
@@ -36,7 +38,9 @@ EVENT_NAME = "public_api_request"
 _PATH_CLASSIFIERS = [
     (re.compile(r"/recitations/(\d+)/?$"), "recitation"),
     (re.compile(r"/recitations/?$"), "recitation"),
+    (re.compile(r"/reciters/(\d+)/?$"), "reciter"),
     (re.compile(r"/reciters/?$"), "reciter"),
+    (re.compile(r"/riwayahs/(\d+)/?$"), "riwayah"),
     (re.compile(r"/riwayahs/?$"), "riwayah"),
 ]
 
@@ -48,6 +52,101 @@ def _classify_path(path: str) -> tuple[str | None, int | None]:
             accessed_id = int(m.group(1)) if m.lastindex else None
             return entity_type, accessed_id
     return None, None
+
+
+def _resolve_application(request) -> tuple[int | None, str | None]:
+    """Return (application_id, application_name) for OAuth2-authed requests."""
+    token = getattr(request, "access_token", None)
+    if token is None:
+        return None, None
+    application = getattr(token, "application", None)
+    if application is None:
+        return None, None
+    return getattr(application, "id", None), getattr(application, "name", None)
+
+
+def _detect_auth_method(request) -> str:
+    """One of: 'oauth2', 'jwt', 'session', 'anonymous'."""
+    if getattr(request, "access_token", None) is not None:
+        return "oauth2"
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
+        return "anonymous"
+    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    if auth_header.lower().startswith("bearer "):
+        return "jwt"
+    return "session"
+
+
+def _client_ip(request) -> str | None:
+    """Resolve real client IP behind nginx/cloudflare. Used for Mixpanel $ip."""
+    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if xff:
+        # X-Forwarded-For: client, proxy1, proxy2 — first entry is the real client.
+        return xff.split(",")[0].strip() or None
+    return request.META.get("REMOTE_ADDR") or None
+
+
+_KNOWN_FILTER_KEYS = ("reciter_id", "riwayah_id", "qiraah_id")
+
+
+def _parse_query_params(query_string: str) -> dict:
+    """Extract first-class properties from the query string.
+
+    NOTE: query_string itself is also captured raw on the event. The public
+    API filter schema does not accept any PII fields (see
+    apps/content/api/public/*.py — only IDs, page, search, ordering). If a
+    future endpoint adds a PII-bearing query param, sanitize here first.
+    """
+    if not query_string:
+        return {}
+    parsed = parse_qs(query_string, keep_blank_values=False)
+    result: dict = {}
+
+    page_raw = parsed.get("page", [None])[0]
+    if page_raw:
+        try:
+            result["page"] = int(page_raw)
+        except (TypeError, ValueError):
+            pass
+
+    search = parsed.get("search", [None])[0]
+    if search:
+        result["search"] = search
+
+    for key in _KNOWN_FILTER_KEYS:
+        value = parsed.get(key, [None])[0]
+        if value:
+            try:
+                result[f"filter_{key}"] = int(value)
+            except (TypeError, ValueError):
+                result[f"filter_{key}"] = value
+
+    ordering = parsed.get("ordering", [None])[0]
+    if ordering:
+        result["ordering"] = ordering
+
+    return result
+
+
+def _extract_error_code(response) -> str | None:
+    """Pull the error_name from an ItqanError response body, if present."""
+    if response.status_code < 400:
+        return None
+    if getattr(response, "streaming", False):
+        return None
+    body = getattr(response, "content", None)
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(payload, dict):
+        code = payload.get("error_name")
+        if isinstance(code, str):
+            return code
+    return None
 
 
 class UsageTrackingMiddleware:
@@ -75,10 +174,16 @@ class UsageTrackingMiddleware:
 
     def _dispatch(self, request, response, latency_ms: int) -> None:
         publisher_id, publisher_slug, publisher_name = resolve_publisher_from_request(request)
+        application_id, application_name = _resolve_application(request)
         distinct_id = self._distinct_id(request)
         entity_ids, entity_names = extract_entities(self._response_body(response))
         entity_type, accessed_entity_id = _classify_path(request.path)
         query_string = request.META.get("QUERY_STRING") or None
+        parsed_qs = _parse_query_params(query_string or "")
+        error_code = _extract_error_code(response)
+        user_agent = request.META.get("HTTP_USER_AGENT") or None
+        ip = _client_ip(request)
+        auth_method = _detect_auth_method(request)
 
         properties = {
             "method": request.method,
@@ -89,12 +194,21 @@ class UsageTrackingMiddleware:
             "publisher_id": publisher_id,
             "publisher_slug": publisher_slug,
             "publisher_name": publisher_name,
+            "application_id": application_id,
+            "application_name": application_name,
+            "auth_method": auth_method,
+            "user_agent": user_agent,
             "entity_ids": entity_ids,
             "entity_names": entity_names,
             "entity_type": entity_type,
             "accessed_entity_id": accessed_entity_id,
             "query_string": query_string,
+            "error_code": error_code,
+            **parsed_qs,
         }
+        if ip:
+            # Mixpanel resolves geo from $ip on ingest and does not store the raw IP.
+            properties["$ip"] = ip
 
         track_api_request_task.delay(
             distinct_id=distinct_id,
@@ -110,7 +224,19 @@ class UsageTrackingMiddleware:
 
     @staticmethod
     def _distinct_id(request) -> str:
+        # OAuth2 client_credentials: request.user is anonymous but the OAuth2
+        # application is the stable identity for that downstream client.
+        token = getattr(request, "access_token", None)
+        if token is not None:
+            application = getattr(token, "application", None)
+            if application is not None:
+                return f"app-{application.id}"
+
         user = getattr(request, "user", None)
         if user is not None and getattr(user, "is_authenticated", False):
             return f"user-{user.pk}"
+
+        # True anonymous — every request gets a fresh ID. Acceptable; we have
+        # no better signal. Most public-API traffic should hit one of the
+        # branches above.
         return f"anon-{uuid.uuid4().hex[:12]}"

--- a/apps/usage_tracking/middlewares/usage_tracking_middleware.py
+++ b/apps/usage_tracking/middlewares/usage_tracking_middleware.py
@@ -6,8 +6,8 @@ import json
 import logging
 import re
 import time
-import uuid
 from urllib.parse import parse_qs
+import uuid
 
 from apps.usage_tracking.services.entity_extractor import extract_entities
 from apps.usage_tracking.services.publisher_resolver import resolve_publisher_from_request
@@ -72,7 +72,7 @@ def _detect_auth_method(request) -> str:
     user = getattr(request, "user", None)
     if user is None or not getattr(user, "is_authenticated", False):
         return "anonymous"
-    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    auth_header = request.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         return "jwt"
     return "session"
@@ -80,7 +80,7 @@ def _detect_auth_method(request) -> str:
 
 def _client_ip(request) -> str | None:
     """Resolve real client IP behind nginx/cloudflare. Used for Mixpanel $ip."""
-    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    xff = request.headers.get("x-forwarded-for", "")
     if xff:
         # X-Forwarded-For: client, proxy1, proxy2 — first entry is the real client.
         return xff.split(",")[0].strip() or None
@@ -181,7 +181,7 @@ class UsageTrackingMiddleware:
         query_string = request.META.get("QUERY_STRING") or None
         parsed_qs = _parse_query_params(query_string or "")
         error_code = _extract_error_code(response)
-        user_agent = request.META.get("HTTP_USER_AGENT") or None
+        user_agent = request.headers.get("user-agent") or None
         ip = _client_ip(request)
         auth_method = _detect_auth_method(request)
 

--- a/apps/usage_tracking/services/entity_extractor.py
+++ b/apps/usage_tracking/services/entity_extractor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-MAX_ENTITY_IDS = 100
+MAX_ENTITY_IDS = 1000  # was 100; matches Ninja MAX_PAGE_SIZE
 _LIST_KEYS = ("items", "results", "data")
 _NAME_KEYS = ("name_en", "name", "title_en", "title")
 

--- a/apps/usage_tracking/tests/test_entity_extractor.py
+++ b/apps/usage_tracking/tests/test_entity_extractor.py
@@ -33,13 +33,13 @@ class TestEntityExtractor:
 
         assert extract_entity_ids(body) == [99]
 
-    def test_extract_more_than_100_truncates(self):
-        body = json.dumps([{"id": i} for i in range(150)]).encode()
+    def test_extract_more_than_max_truncates(self):
+        body = json.dumps([{"id": i} for i in range(1500)]).encode()
 
         result = extract_entity_ids(body)
 
-        assert len(result) == 100
-        assert result == list(range(100))
+        assert len(result) == 1000
+        assert result == list(range(1000))
 
     def test_extract_no_id_field_returns_empty(self):
         body = json.dumps([{"name": "no id here"}, {"name": "neither"}]).encode()

--- a/apps/usage_tracking/tests/test_middleware.py
+++ b/apps/usage_tracking/tests/test_middleware.py
@@ -1,10 +1,19 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse, StreamingHttpResponse
 from django.test import RequestFactory
 
-from apps.usage_tracking.middlewares.usage_tracking_middleware import UsageTrackingMiddleware, _classify_path
+from apps.usage_tracking.middlewares.usage_tracking_middleware import (
+    UsageTrackingMiddleware,
+    _classify_path,
+    _client_ip,
+    _detect_auth_method,
+    _extract_error_code,
+    _parse_query_params,
+    _resolve_application,
+)
 
 
 class _Resp(HttpResponse):
@@ -49,6 +58,11 @@ class TestUsageTrackingMiddleware:
         assert "entity_type" in props
         assert "accessed_entity_id" in props
         assert "query_string" in props
+        assert "application_id" in props
+        assert "application_name" in props
+        assert "auth_method" in props
+        assert "user_agent" in props
+        assert "error_code" in props
 
     @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
     def test_excluded_path_portal_skipped(self, mock_task):
@@ -156,3 +170,149 @@ class TestClassifyPath:
 
     def test_unknown_path_returns_none(self):
         assert _classify_path("/portal/stats/") == (None, None)
+
+
+class TestDistinctId:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_oauth2_client_credentials_uses_app_id(self):
+        request = self.factory.get("/reciters/")
+        request.user = AnonymousUser()
+        request.access_token = SimpleNamespace(application=SimpleNamespace(id=42))
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "app-42"
+
+    def test_jwt_authenticated_uses_user_pk(self):
+        request = self.factory.get("/reciters/")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "user-99"
+
+    def test_oauth2_token_takes_precedence_over_user(self):
+        request = self.factory.get("/reciters/")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+        request.access_token = SimpleNamespace(application=SimpleNamespace(id=42))
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "app-42"
+
+    def test_anonymous_falls_back_to_uuid(self):
+        request = self.factory.get("/reciters/")
+        request.user = AnonymousUser()
+
+        result = UsageTrackingMiddleware._distinct_id(request)
+
+        assert result.startswith("anon-")
+        assert len(result) == 17  # "anon-" + 12 hex chars
+
+
+class TestClassifyPathDetailEndpoints:
+    def test_reciter_detail(self):
+        assert _classify_path("/reciters/7/") == ("reciter", 7)
+
+    def test_riwayah_detail(self):
+        assert _classify_path("/riwayahs/2/") == ("riwayah", 2)
+
+
+class TestDetectAuthMethod:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_oauth2_when_access_token_set(self):
+        request = self.factory.get("/")
+        request.access_token = SimpleNamespace()
+        request.user = AnonymousUser()
+        assert _detect_auth_method(request) == "oauth2"
+
+    def test_jwt_when_bearer_header(self):
+        request = self.factory.get("/", HTTP_AUTHORIZATION="Bearer xyz")
+        request.user = SimpleNamespace(is_authenticated=True)
+        assert _detect_auth_method(request) == "jwt"
+
+    def test_session_when_authed_no_bearer(self):
+        request = self.factory.get("/")
+        request.user = SimpleNamespace(is_authenticated=True)
+        assert _detect_auth_method(request) == "session"
+
+    def test_anonymous_when_unauthed(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        assert _detect_auth_method(request) == "anonymous"
+
+
+class TestParseQueryParams:
+    def test_empty_returns_empty(self):
+        assert _parse_query_params("") == {}
+
+    def test_extracts_page(self):
+        assert _parse_query_params("page=3") == {"page": 3}
+
+    def test_extracts_search(self):
+        assert _parse_query_params("search=mashary") == {"search": "mashary"}
+
+    def test_extracts_filters_as_int(self):
+        result = _parse_query_params("reciter_id=6&riwayah_id=2")
+        assert result == {"filter_reciter_id": 6, "filter_riwayah_id": 2}
+
+    def test_extracts_ordering(self):
+        assert _parse_query_params("ordering=-name") == {"ordering": "-name"}
+
+    def test_combined(self):
+        result = _parse_query_params("page=2&search=hafs&reciter_id=6&ordering=name")
+        assert result == {
+            "page": 2,
+            "search": "hafs",
+            "filter_reciter_id": 6,
+            "ordering": "name",
+        }
+
+    def test_invalid_page_skipped(self):
+        assert _parse_query_params("page=abc") == {}
+
+
+class TestExtractErrorCode:
+    def test_2xx_returns_none(self):
+        resp = HttpResponse(b'{"error_name": "should_be_ignored"}', status=200)
+        assert _extract_error_code(resp) is None
+
+    def test_4xx_with_error_name_extracts(self):
+        resp = HttpResponse(b'{"error_name": "validation_failed", "message": "bad"}', status=400)
+        assert _extract_error_code(resp) == "validation_failed"
+
+    def test_4xx_without_error_name_returns_none(self):
+        resp = HttpResponse(b'{"foo": "bar"}', status=400)
+        assert _extract_error_code(resp) is None
+
+    def test_streaming_returns_none(self):
+        resp = StreamingHttpResponse(iter([b"chunk"]), status=400)
+        assert _extract_error_code(resp) is None
+
+
+class TestResolveApplication:
+    def test_no_token_returns_none_pair(self):
+        request = SimpleNamespace()
+        assert _resolve_application(request) == (None, None)
+
+    def test_token_with_application(self):
+        request = SimpleNamespace(access_token=SimpleNamespace(
+            application=SimpleNamespace(id=7, name="my-app")
+        ))
+        assert _resolve_application(request) == (7, "my-app")
+
+
+class TestClientIp:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_xff_first_entry_wins(self):
+        request = self.factory.get("/", HTTP_X_FORWARDED_FOR="1.2.3.4, 5.6.7.8")
+        assert _client_ip(request) == "1.2.3.4"
+
+    def test_falls_back_to_remote_addr(self):
+        request = self.factory.get("/", REMOTE_ADDR="9.9.9.9")
+        assert _client_ip(request) == "9.9.9.9"
+
+    def test_returns_none_when_neither_present(self):
+        request = self.factory.get("/")
+        request.META.pop("REMOTE_ADDR", None)
+        assert _client_ip(request) is None

--- a/apps/usage_tracking/tests/test_middleware.py
+++ b/apps/usage_tracking/tests/test_middleware.py
@@ -294,9 +294,7 @@ class TestResolveApplication:
         assert _resolve_application(request) == (None, None)
 
     def test_token_with_application(self):
-        request = SimpleNamespace(access_token=SimpleNamespace(
-            application=SimpleNamespace(id=7, name="my-app")
-        ))
+        request = SimpleNamespace(access_token=SimpleNamespace(application=SimpleNamespace(id=7, name="my-app")))
         assert _resolve_application(request) == (7, "my-app")
 
 


### PR DESCRIPTION
## Summary
Closes outstanding bugs from the post-PR-#320 audit and adds high-signal properties.

### Bug fixes
- 🔴 **distinct_id stability** — OAuth2 client_credentials calls were getting a fresh `anon-{uuid}` per request, making Mixpanel cohort/uniqueness analysis impossible. Now: `app-{application_id}` for OAuth2 cc, `user-{pk}` for JWT, `anon-uuid` only for true anonymous.
- 🔴 **entity_ids cap** — raised 100 → 1000 to match Ninja `MAX_PAGE_SIZE`. Stops silently dropping entities on large-page responses.

### New event properties
- `application_id` / `application_name` — which OAuth2 app at this publisher (multiple apps per publisher = mobile/web/jobs)
- `auth_method` — `oauth2` / `jwt` / `session` / `anonymous`
- `error_code` — semantic name from `ItqanError` on 4xx/5xx (not just numeric status_code)
- `user_agent` — full UA; Mixpanel auto-parses browser/OS/device
- `\$ip` — special Mixpanel property; resolves country/region/city on ingest, IP not stored
- Parsed query params as first-class properties: `page`, `search`, `filter_reciter_id`, `filter_riwayah_id`, `filter_qiraah_id`, `ordering`

### Future-proofing
- `_PATH_CLASSIFIERS` matches `/reciters/{id}/` and `/riwayahs/{id}/` detail endpoints. Safe to land before those endpoints exist.

## Test plan
- [x] 78 unit tests pass locally
- [ ] CI green
- [ ] After staging deploy: hit public API via OAuth2, verify Mixpanel event has new properties, verify distinct_id is stable across calls from same app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request tracking now captures OAuth2 application details, authentication methods, client IP addresses, and error codes
  * Increased entity extraction processing capacity from 100 to 1,000 items per operation
  * Improved request path recognition for additional resource types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->