### PR TITLE
Dedupe header lookup in get_publisher_domain middleware

### DIFF
--- a/apps/publishers/middlewares/publisher_middleware.py
+++ b/apps/publishers/middlewares/publisher_middleware.py
@@ -59,11 +59,8 @@ def get_publisher_domain(request: HttpRequest, header_name: str) -> Domain | Non
     Retrieve a domain based on the Host header
     """
 
-    referer = (
-        request.headers.get(header_name).rstrip("/").replace("https://", "").replace("http://", "")
-        if request.headers.get(header_name)
-        else None
-    )
+    header_value = request.headers.get(header_name)
+    referer = header_value.rstrip("/").replace("https://", "").replace("http://", "") if header_value else None
     if not referer:
         return None
 


### PR DESCRIPTION
## Summary

Small middleware cleanup. `get_publisher_domain` in `apps/publishers/middlewares/publisher_middleware.py` was calling `request.headers.get(header_name)` twice inside the same conditional expression — once for the guard and once on the truthy branch. Stashing the value in a local removes the duplicate lookup and lets `mypy` narrow the `str | None` return so `.rstrip(...)` no longer trips the `union-attr` rule.

## Diff

```diff
-    referer = (
-        request.headers.get(header_name).rstrip("/").replace("https://", "").replace("http://", "")
-        if request.headers.get(header_name)
-        else None
-    )
+    header_value = request.headers.get(header_name)
+    referer = header_value.rstrip("/").replace("https://", "").replace("http://", "") if header_value else None
```

Behaviour is identical for present, missing, and empty headers.

## Verification

- `pre-commit run --all-files` passes (black collapsed my multi-line ternary back into a single line — kept that).
- `mypy --explicit-package-bases apps/publishers/middlewares/publisher_middleware.py` is clean for this file (the unrelated mypy noise in other modules is pre-existing on `staging`).
- No behavioural test added because the change is a pure refactor of a hot helper that is already covered transitively by the middleware test suite. Happy to add a focused unit test if you'd like.

## Notes

- PR targets `staging` per CONTRIBUTING.md branch flow.
- Branch name follows `feat/<short-description>`.
