### PR TITLE
Handle missing context in DetailPublisherOut.serialize_icon_url

### DIFF
--- a/apps/publishers/api/internal/publishers_detail.py
+++ b/apps/publishers/api/internal/publishers_detail.py
@@ -24,7 +24,7 @@ class DetailPublisherOut(Schema):
 
     @field_serializer("icon_url")
     def serialize_icon_url(self, value, info: SerializationInfo) -> str:
-        request = info.context.get("request")
+        request = (info.context or {}).get("request")
         if request and isinstance(value, str) and not value.startswith("https"):
             return request.build_absolute_uri(value)
 


### PR DESCRIPTION
## Summary

`DetailPublisherOut.serialize_icon_url` calls `info.context.get("request")` directly. `SerializationInfo.context` is typed `Any | None`, so any caller that serializes this schema without a context raises `AttributeError` before the truthy `request` guard further down gets a chance to run.

Fall back to an empty dict when `context` is `None`. The normal request-bound serialization path is unchanged.

## Diff

```diff
-        request = info.context.get("request")
+        request = (info.context or {}).get("request")
```

## Verification

- `pre-commit run --files apps/publishers/api/internal/publishers_detail.py` passes (black/isort/ruff/bandit/pyupgrade/django-upgrade).
- `mypy --explicit-package-bases apps/publishers/api/internal/publishers_detail.py` no longer flags the `union-attr` error on this line.

## Notes

- Branch and target follow CONTRIBUTING.md: `feat/<short-description>` → `staging`.
- Same one-line pattern would tighten `apps/core/ninja_utils/types.py:12` (`info.context["request"]`); leaving that for a follow-up since it sits in shared infra and feels worth a separate, narrower diff.
