### PR TITLE
chore: wire pytest-cov into CI and document TDD setup (IQA-16)

### DIFF
--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -111,7 +111,14 @@ jobs:
         run: docker compose -f docker-compose.local.yml run --rm django uv run python manage.py migrate
 
       - name: Run Django Tests
-        run: docker compose -f docker-compose.local.yml run --rm django uv run pytest
+        run: docker compose -f docker-compose.local.yml run --rm django uv run pytest --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
 
       - name: Tear down the Stack
         run: docker compose -f docker-compose.local.yml down

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,64 @@ Thank you for helping improve Quranic accessibility. This guide keeps contributi
 - See `README.md` -> Quick Start
 
 ## Testing
-- Use `pytest` (not `manage.py test`)
+
+### Running tests
+
+Use `pytest` (not `manage.py test`). From the project root with the dev virtualenv active:
+
+```bash
+# Run all tests with coverage (same as CI)
+uv run pytest
+
+# Run a single app's tests (faster feedback)
+uv run pytest apps/content/tests/
+
+# Skip coverage for a quick local run
+uv run pytest --no-cov
+```
+
+### Framework
+
+| Tool | Purpose |
+|---|---|
+| `pytest-django` | Django test runner integration |
+| `pytest-cov` | Coverage measurement (sources: `apps/`) |
+| `model-bakery` | Model factories for test data |
+| `moto` | AWS/S3 mock for R2 storage tests |
+| `freezegun` | Time-freezing for date-sensitive tests |
+| `responses` | HTTP request mocking |
+
+Configuration lives in `pyproject.toml` under `[tool.pytest.ini_options]` and `[tool.coverage.*]`.
+
+### Coverage
+
+Every `pytest` run prints a terminal coverage report (missing lines highlighted). In CI, a `coverage.xml` artifact is uploaded to the GitHub Actions run for each PR.
+
+Coverage is measured over `apps/` and excludes migrations and test files themselves.
+
+### Test layout
+
+Tests live alongside each Django app under `apps/<app>/tests/`, mirroring the module they cover:
+
+```
+apps/
+  content/
+    tests/
+      public/          ← tests for the Public API surface
+      portal/          ← tests for the Portal API surface
+      tenant/          ← tests for the Tenant API surface
+      test_*.py        ← model / service tests
+  users/tests/
+  publishers/tests/
+  ...
+```
+
+### Standards
+
 - Follow Arrange–Act–Assert (AAA)
 - Name tests: `test_<function_name>_where<criteria>_should<expected_results>`
+- Every new feature or bug fix requires a corresponding test
+- A failing test blocks the CI pipeline — PRs cannot merge with a red test suite
 
 ## API & Errors
 - APIs: Django Ninja; document responses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ ninja-keys = { git = "https://github.com/hassaanalansary/ninja-keys.git" }
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ds=config.settings.development --reuse-db --import-mode=importlib"
+addopts = "--ds=config.settings.development --reuse-db --import-mode=importlib --cov=apps --cov-report=term-missing"
 filterwarnings = [
      "ignore::DeprecationWarning",
 ]


### PR DESCRIPTION
## Summary

Wires pytest-cov into CI and documents TDD setup for IQA-16.

**Note:** Branch renamed from `feat/iqa-16-tdd-framework` → `feature/iqa-16-tdd-framework` to satisfy org branch-naming gate (replaces closed PR #351).

## Test plan

- [ ] Branch naming check passes
- [ ] CI pytest job passes with coverage
- [ ] Merge to staging after CTO review

Related: [IQA-16](https://github.com/Itqan-community/cms-backend/issues) / IQA-24 hotfix

Made with [Cursor](https://cursor.com)