### PR TITLE
Fix DB connection exhaustion - remove Asset query from Celery task, add PgBouncer

### DIFF
--- a/apps/usage_tracking/middlewares/usage_tracking_middleware.py
+++ b/apps/usage_tracking/middlewares/usage_tracking_middleware.py
@@ -1,0 +1,262 @@
+"""Capture public API requests and dispatch a Celery tracking task."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from urllib.parse import parse_qs
+import uuid
+
+from apps.usage_tracking.services.entity_extractor import extract_entities
+from apps.usage_tracking.services.publisher_resolver import resolve_publisher_from_request
+from apps.usage_tracking.tasks import track_api_request_task
+
+logger = logging.getLogger(__name__)
+
+EXCLUDED_PREFIXES = (
+    "/portal",
+    "/cms-api",
+    "/tenant",
+    "/accounts",
+    "/django-admin",
+    "/o",
+    "/health",
+    "/developers-api",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/favicon.ico",
+    "/robots.txt",
+    "/static",
+    "/media",
+)
+
+EVENT_NAME = "public_api_request"
+
+_PATH_CLASSIFIERS = [
+    (re.compile(r"/recitations/(\d+)/?$"), "recitation"),
+    (re.compile(r"/recitations/?$"), "recitation"),
+    (re.compile(r"/reciters/(\d+)/?$"), "reciter"),
+    (re.compile(r"/reciters/?$"), "reciter"),
+    (re.compile(r"/riwayahs/(\d+)/?$"), "riwayah"),
+    (re.compile(r"/riwayahs/?$"), "riwayah"),
+]
+
+
+def _classify_path(path: str) -> tuple[str | None, int | None]:
+    for pattern, entity_type in _PATH_CLASSIFIERS:
+        m = pattern.search(path)
+        if m:
+            accessed_id = int(m.group(1)) if m.lastindex else None
+            return entity_type, accessed_id
+    return None, None
+
+
+_CONTENT_TYPE_LABELS: dict[tuple[str, bool], str] = {
+    ("recitation", False): "Browse Recordings",
+    ("recitation", True): "Stream Audio",
+    ("reciter", False): "Browse Reciters",
+    ("reciter", True): "View Reciter",
+    ("riwayah", False): "Browse Riwayahs",
+    ("riwayah", True): "Browse Riwayahs",
+}
+
+
+def _friendly_content_type(entity_type: str | None, accessed_id: int | None) -> str | None:
+    if entity_type is None:
+        return None
+    return _CONTENT_TYPE_LABELS.get((entity_type, accessed_id is not None))
+
+
+def _resolve_application(request) -> tuple[int | None, str | None]:
+    """Return (application_id, application_name) for OAuth2-authed requests."""
+    token = getattr(request, "access_token", None)
+    if token is None:
+        return None, None
+    application = getattr(token, "application", None)
+    if application is None:
+        return None, None
+    return getattr(application, "id", None), getattr(application, "name", None)
+
+
+def _detect_auth_method(request) -> str:
+    """One of: 'oauth2', 'jwt', 'session', 'anonymous'."""
+    if getattr(request, "access_token", None) is not None:
+        return "oauth2"
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
+        return "anonymous"
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return "jwt"
+    return "session"
+
+
+def _client_ip(request) -> str | None:
+    """Resolve real client IP behind nginx/cloudflare. Used for Mixpanel $ip."""
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        # X-Forwarded-For: client, proxy1, proxy2 — first entry is the real client.
+        return xff.split(",")[0].strip() or None
+    return request.META.get("REMOTE_ADDR") or None
+
+
+_KNOWN_FILTER_KEYS = ("reciter_id", "riwayah_id", "qiraah_id")
+
+
+def _parse_query_params(query_string: str) -> dict:
+    """Extract first-class properties from the query string.
+
+    NOTE: query_string itself is also captured raw on the event. The public
+    API filter schema does not accept any PII fields (see
+    apps/content/api/public/*.py — only IDs, page, search, ordering). If a
+    future endpoint adds a PII-bearing query param, sanitize here first.
+    """
+    if not query_string:
+        return {}
+    parsed = parse_qs(query_string, keep_blank_values=False)
+    result: dict = {}
+
+    page_raw = parsed.get("page", [None])[0]
+    if page_raw:
+        try:
+            result["page"] = int(page_raw)
+        except (TypeError, ValueError):
+            pass
+
+    search = parsed.get("search", [None])[0]
+    if search:
+        result["search"] = search
+
+    for key in _KNOWN_FILTER_KEYS:
+        value = parsed.get(key, [None])[0]
+        if value:
+            try:
+                result[f"filter_{key}"] = int(value)
+            except (TypeError, ValueError):
+                result[f"filter_{key}"] = value
+
+    ordering = parsed.get("ordering", [None])[0]
+    if ordering:
+        result["ordering"] = ordering
+
+    return result
+
+
+def _extract_error_code(response) -> str | None:
+    """Pull the error_name from an ItqanError response body, if present."""
+    if response.status_code < 400:
+        return None
+    if getattr(response, "streaming", False):
+        return None
+    body = getattr(response, "content", None)
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(payload, dict):
+        code = payload.get("error_name")
+        if isinstance(code, str):
+            return code
+    return None
+
+
+class UsageTrackingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self._is_excluded(request.path):
+            return self.get_response(request)
+
+        start = time.monotonic()
+        response = self.get_response(request)
+        latency_ms = int((time.monotonic() - start) * 1000)
+
+        try:
+            self._dispatch(request, response, latency_ms)
+        except Exception:
+            logger.exception("usage_tracking middleware dispatch failed")
+
+        return response
+
+    @staticmethod
+    def _is_excluded(path: str) -> bool:
+        return any(path == p or path.startswith(p + "/") for p in EXCLUDED_PREFIXES)
+
+    def _dispatch(self, request, response, latency_ms: int) -> None:
+        publisher_id, publisher_slug, publisher_name = resolve_publisher_from_request(request)
+        application_id, application_name = _resolve_application(request)
+        distinct_id = self._distinct_id(request)
+        entity_ids, entity_names = extract_entities(self._response_body(response))
+        entity_type, accessed_entity_id = _classify_path(request.path)
+        content_type = _friendly_content_type(entity_type, accessed_entity_id)
+        accessed_entity_name = entity_names[0] if (accessed_entity_id is not None and entity_names) else None
+        query_string = request.META.get("QUERY_STRING") or None
+        parsed_qs = _parse_query_params(query_string or "")
+        error_code = _extract_error_code(response)
+        user_agent = request.headers.get("user-agent") or None
+        ip = _client_ip(request)
+        auth_method = _detect_auth_method(request)
+
+        properties = {
+            "method": request.method,
+            "path": request.path,
+            "endpoint": f"{request.method} {request.path}",
+            "status_code": response.status_code,
+            "latency_ms": latency_ms,
+            "publisher_id": publisher_id,
+            "publisher_slug": publisher_slug,
+            "publisher_name": publisher_name,
+            "application_id": application_id,
+            "application_name": application_name,
+            "auth_method": auth_method,
+            "user_agent": user_agent,
+            "entity_ids": entity_ids,
+            "entity_names": entity_names,
+            "entity_type": entity_type,
+            "accessed_entity_id": accessed_entity_id,
+            "accessed_entity_name": accessed_entity_name,
+            "content_type": content_type,
+            "query_string": query_string,
+            "error_code": error_code,
+            **parsed_qs,
+        }
+        if ip:
+            # Mixpanel resolves geo from $ip on ingest and does not store the raw IP.
+            properties["$ip"] = ip
+
+        track_api_request_task.delay(
+            distinct_id=distinct_id,
+            event=EVENT_NAME,
+            properties=properties,
+        )
+
+    @staticmethod
+    def _response_body(response) -> bytes | None:
+        if getattr(response, "streaming", False):
+            return None
+        return getattr(response, "content", None)
+
+    @staticmethod
+    def _distinct_id(request) -> str:
+        # OAuth2 client_credentials: request.user is anonymous but the OAuth2
+        # application is the stable identity for that downstream client.
+        token = getattr(request, "access_token", None)
+        if token is not None:
+            application = getattr(token, "application", None)
+            if application is not None:
+                return f"app-{application.id}"
+
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            return f"user-{user.pk}"
+
+        # True anonymous — every request gets a fresh ID. Acceptable; we have
+        # no better signal. Most public-API traffic should hit one of the
+        # branches above.
+        return f"anon-{uuid.uuid4().hex[:12]}"

--- a/apps/usage_tracking/tasks.py
+++ b/apps/usage_tracking/tasks.py
@@ -41,11 +41,5 @@ def track_api_request_task(
     if not distinct_id:
         return
 
-    accessed_entity_id = properties.get("accessed_entity_id")
-    if accessed_entity_id is not None:
-        from apps.content.models import Asset
-
-        row = Asset.objects.filter(pk=accessed_entity_id).values("name").first()
-        properties = {**properties, "accessed_entity_name": row["name"] if row else None}
     client = _build_ingest_client()
     client.track(distinct_id, event, properties, meta=meta)

--- a/apps/usage_tracking/tests/test_middleware.py
+++ b/apps/usage_tracking/tests/test_middleware.py
@@ -1,0 +1,371 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse, StreamingHttpResponse
+from django.test import RequestFactory
+
+from apps.usage_tracking.middlewares.usage_tracking_middleware import (
+    UsageTrackingMiddleware,
+    _classify_path,
+    _client_ip,
+    _detect_auth_method,
+    _extract_error_code,
+    _friendly_content_type,
+    _parse_query_params,
+    _resolve_application,
+)
+
+
+class _Resp(HttpResponse):
+    pass
+
+
+def _make_middleware(response_body=b'[{"id": 1}, {"id": 2}]', status=200):
+    def get_response(request):
+        return _Resp(content=response_body, status=status, content_type="application/json")
+
+    return UsageTrackingMiddleware(get_response)
+
+
+class TestUsageTrackingMiddleware:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_tracked_path_dispatches_celery_task(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+        mw = _make_middleware()
+        request = self.factory.get("/reciters")
+        request.access_token = SimpleNamespace(id=7, user=SimpleNamespace(id=99))
+
+        mw(request)
+
+        assert mock_task.delay.called
+        _, kwargs = mock_task.delay.call_args
+        assert kwargs["event"] == "public_api_request"
+        props = kwargs["properties"]
+        assert props["publisher_id"] == 42
+        assert props["publisher_slug"] == "acme"
+        assert props["publisher_name"] == "Acme Publisher"
+        assert props["endpoint"] == "GET /reciters"
+        assert props["status_code"] == 200
+        assert "latency_ms" in props
+        assert props["entity_ids"] == [1, 2]
+        assert "method" in props
+        assert "path" in props
+        assert "entity_names" in props
+        assert "entity_type" in props
+        assert "accessed_entity_id" in props
+        assert "accessed_entity_name" in props
+        assert "query_string" in props
+        assert "application_id" in props
+        assert "application_name" in props
+        assert "auth_method" in props
+        assert "user_agent" in props
+        assert "error_code" in props
+        assert "content_type" in props
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    def test_excluded_path_portal_skipped(self, mock_task):
+        mw = _make_middleware()
+        request = self.factory.get("/portal/stats")
+
+        mw(request)
+
+        mock_task.delay.assert_not_called()
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    def test_excluded_path_admin_skipped(self, mock_task):
+        mw = _make_middleware()
+        request = self.factory.get("/django-admin/")
+
+        mw(request)
+
+        mock_task.delay.assert_not_called()
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    def test_excluded_path_oauth_skipped(self, mock_task):
+        mw = _make_middleware()
+        request = self.factory.get("/o/token/")
+
+        mw(request)
+
+        mock_task.delay.assert_not_called()
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_unauthenticated_request_still_tracked_with_anon(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (None, None, None)
+        mw = _make_middleware()
+        request = self.factory.get("/reciters")
+
+        mw(request)
+
+        assert mock_task.delay.called
+        _, kwargs = mock_task.delay.call_args
+        assert kwargs["distinct_id"].startswith("anon-")
+        assert kwargs["properties"]["publisher_id"] is None
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_celery_dispatch_failure_does_not_break_request(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+        mock_task.delay.side_effect = RuntimeError("broker down")
+        mw = _make_middleware()
+        request = self.factory.get("/reciters")
+
+        response = mw(request)
+
+        assert response.status_code == 200
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_streaming_response_is_not_buffered(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+
+        def get_response(request):
+            return StreamingHttpResponse(iter([b"chunk1", b"chunk2"]), status=200)
+
+        mw = UsageTrackingMiddleware(get_response)
+        request = self.factory.get("/reciters")
+
+        response = mw(request)
+
+        assert response.streaming is True
+        assert mock_task.delay.called
+        _, kwargs = mock_task.delay.call_args
+        assert kwargs["properties"]["entity_ids"] == []
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_accessed_entity_name_extracted_from_response_body(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+        body = b'{"id": 5, "name_en": "Ibn Kathir", "slug": "ibn-kathir"}'
+        mw = _make_middleware(response_body=body)
+        request = self.factory.get("/reciters/5/")
+
+        mw(request)
+
+        _, kwargs = mock_task.delay.call_args
+        props = kwargs["properties"]
+        assert props["accessed_entity_id"] == 5
+        assert props["accessed_entity_name"] == "Ibn Kathir"
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_accessed_entity_name_none_for_list_endpoints(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+        mw = _make_middleware(response_body=b'[{"id": 1}, {"id": 2}]')
+        request = self.factory.get("/reciters/")
+
+        mw(request)
+
+        _, kwargs = mock_task.delay.call_args
+        props = kwargs["properties"]
+        assert props["accessed_entity_id"] is None
+        assert props["accessed_entity_name"] is None
+
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.track_api_request_task")
+    @patch("apps.usage_tracking.middlewares.usage_tracking_middleware.resolve_publisher_from_request")
+    def test_distinct_id_uses_user_id_when_authed(self, mock_resolve, mock_task):
+        mock_resolve.return_value = (42, "acme", "Acme Publisher")
+        mw = _make_middleware()
+        request = self.factory.get("/reciters")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+
+        mw(request)
+
+        _, kwargs = mock_task.delay.call_args
+        assert kwargs["distinct_id"] == "user-99"
+
+
+class TestClassifyPath:
+    def test_recitation_detail(self):
+        assert _classify_path("/public-api/v1/recitations/123/") == ("recitation", 123)
+
+    def test_recitation_list(self):
+        entity_type, accessed_id = _classify_path("/public-api/v1/recitations/")
+        assert entity_type == "recitation"
+        assert accessed_id is None
+
+    def test_reciters_list(self):
+        entity_type, accessed_id = _classify_path("/public-api/v1/reciters/")
+        assert entity_type == "reciter"
+        assert accessed_id is None
+
+    def test_riwayahs_list(self):
+        entity_type, accessed_id = _classify_path("/public-api/v1/riwayahs/")
+        assert entity_type == "riwayah"
+        assert accessed_id is None
+
+    def test_unknown_path_returns_none(self):
+        assert _classify_path("/portal/stats/") == (None, None)
+
+
+class TestDistinctId:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_oauth2_client_credentials_uses_app_id(self):
+        request = self.factory.get("/reciters/")
+        request.user = AnonymousUser()
+        request.access_token = SimpleNamespace(application=SimpleNamespace(id=42))
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "app-42"
+
+    def test_jwt_authenticated_uses_user_pk(self):
+        request = self.factory.get("/reciters/")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "user-99"
+
+    def test_oauth2_token_takes_precedence_over_user(self):
+        request = self.factory.get("/reciters/")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+        request.access_token = SimpleNamespace(application=SimpleNamespace(id=42))
+
+        assert UsageTrackingMiddleware._distinct_id(request) == "app-42"
+
+    def test_anonymous_falls_back_to_uuid(self):
+        request = self.factory.get("/reciters/")
+        request.user = AnonymousUser()
+
+        result = UsageTrackingMiddleware._distinct_id(request)
+
+        assert result.startswith("anon-")
+        assert len(result) == 17  # "anon-" + 12 hex chars
+
+
+class TestClassifyPathDetailEndpoints:
+    def test_reciter_detail(self):
+        assert _classify_path("/reciters/7/") == ("reciter", 7)
+
+    def test_riwayah_detail(self):
+        assert _classify_path("/riwayahs/2/") == ("riwayah", 2)
+
+
+class TestDetectAuthMethod:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_oauth2_when_access_token_set(self):
+        request = self.factory.get("/")
+        request.access_token = SimpleNamespace()
+        request.user = AnonymousUser()
+        assert _detect_auth_method(request) == "oauth2"
+
+    def test_jwt_when_bearer_header(self):
+        request = self.factory.get("/", HTTP_AUTHORIZATION="Bearer xyz")
+        request.user = SimpleNamespace(is_authenticated=True)
+        assert _detect_auth_method(request) == "jwt"
+
+    def test_session_when_authed_no_bearer(self):
+        request = self.factory.get("/")
+        request.user = SimpleNamespace(is_authenticated=True)
+        assert _detect_auth_method(request) == "session"
+
+    def test_anonymous_when_unauthed(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        assert _detect_auth_method(request) == "anonymous"
+
+
+class TestParseQueryParams:
+    def test_empty_returns_empty(self):
+        assert _parse_query_params("") == {}
+
+    def test_extracts_page(self):
+        assert _parse_query_params("page=3") == {"page": 3}
+
+    def test_extracts_search(self):
+        assert _parse_query_params("search=mashary") == {"search": "mashary"}
+
+    def test_extracts_filters_as_int(self):
+        result = _parse_query_params("reciter_id=6&riwayah_id=2")
+        assert result == {"filter_reciter_id": 6, "filter_riwayah_id": 2}
+
+    def test_extracts_ordering(self):
+        assert _parse_query_params("ordering=-name") == {"ordering": "-name"}
+
+    def test_combined(self):
+        result = _parse_query_params("page=2&search=hafs&reciter_id=6&ordering=name")
+        assert result == {
+            "page": 2,
+            "search": "hafs",
+            "filter_reciter_id": 6,
+            "ordering": "name",
+        }
+
+    def test_invalid_page_skipped(self):
+        assert _parse_query_params("page=abc") == {}
+
+
+class TestExtractErrorCode:
+    def test_2xx_returns_none(self):
+        resp = HttpResponse(b'{"error_name": "should_be_ignored"}', status=200)
+        assert _extract_error_code(resp) is None
+
+    def test_4xx_with_error_name_extracts(self):
+        resp = HttpResponse(b'{"error_name": "validation_failed", "message": "bad"}', status=400)
+        assert _extract_error_code(resp) == "validation_failed"
+
+    def test_4xx_without_error_name_returns_none(self):
+        resp = HttpResponse(b'{"foo": "bar"}', status=400)
+        assert _extract_error_code(resp) is None
+
+    def test_streaming_returns_none(self):
+        resp = StreamingHttpResponse(iter([b"chunk"]), status=400)
+        assert _extract_error_code(resp) is None
+
+
+class TestFriendlyContentType:
+    def test_recitation_list(self):
+        assert _friendly_content_type("recitation", None) == "Browse Recordings"
+
+    def test_recitation_detail(self):
+        assert _friendly_content_type("recitation", 13) == "Stream Audio"
+
+    def test_reciter_list(self):
+        assert _friendly_content_type("reciter", None) == "Browse Reciters"
+
+    def test_reciter_detail(self):
+        assert _friendly_content_type("reciter", 7) == "View Reciter"
+
+    def test_riwayah_list(self):
+        assert _friendly_content_type("riwayah", None) == "Browse Riwayahs"
+
+    def test_riwayah_detail(self):
+        assert _friendly_content_type("riwayah", 2) == "Browse Riwayahs"
+
+    def test_unknown_path_returns_none(self):
+        assert _friendly_content_type(None, None) is None
+
+
+class TestResolveApplication:
+    def test_no_token_returns_none_pair(self):
+        request = SimpleNamespace()
+        assert _resolve_application(request) == (None, None)
+
+    def test_token_with_application(self):
+        request = SimpleNamespace(access_token=SimpleNamespace(application=SimpleNamespace(id=7, name="my-app")))
+        assert _resolve_application(request) == (7, "my-app")
+
+
+class TestClientIp:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def test_xff_first_entry_wins(self):
+        request = self.factory.get("/", HTTP_X_FORWARDED_FOR="1.2.3.4, 5.6.7.8")
+        assert _client_ip(request) == "1.2.3.4"
+
+    def test_falls_back_to_remote_addr(self):
+        request = self.factory.get("/", REMOTE_ADDR="9.9.9.9")
+        assert _client_ip(request) == "9.9.9.9"
+
+    def test_returns_none_when_neither_present(self):
+        request = self.factory.get("/")
+        request.META.pop("REMOTE_ADDR", None)
+        assert _client_ip(request) is None

--- a/apps/usage_tracking/tests/test_tasks.py
+++ b/apps/usage_tracking/tests/test_tasks.py
@@ -5,7 +5,7 @@ from apps.usage_tracking.tasks import track_api_request_task
 
 class TestTrackApiRequestTask:
     @patch("apps.usage_tracking.tasks._build_ingest_client")
-    def test_task_fans_out_to_all_clients(self, mock_build):
+    def test_task_sends_to_client(self, mock_build):
         client = MagicMock()
         mock_build.return_value = client
 
@@ -29,48 +29,34 @@ class TestTrackApiRequestTask:
         client.track.assert_not_called()
 
     @patch("apps.usage_tracking.tasks._build_ingest_client")
-    def test_task_fans_out_to_single_client_when_only_one_token(self, mock_build):
+    def test_task_passes_accessed_entity_name_from_properties_without_db(self, mock_build):
+        """Regression: entity name must come from properties, never from a DB query."""
         client = MagicMock()
         mock_build.return_value = client
 
         track_api_request_task.run(
-            distinct_id="user-1",
+            distinct_id="app-7",
             event="public_api_request",
-            properties={},
+            properties={
+                "accessed_entity_id": 99,
+                "accessed_entity_name": "Ibn Kathir",
+                "entity_type": "recitation",
+            },
         )
 
-        client.track.assert_called_once()
-
-    @patch("apps.usage_tracking.tasks._build_ingest_client")
-    def test_task_resolves_accessed_entity_name(self, mock_build):
-        client = MagicMock()
-        mock_build.return_value = client
-
-        with patch("apps.content.models.Asset.objects") as mock_qs:
-            mock_qs.filter.return_value.values.return_value.first.return_value = {"name": "Hafs An Asim"}
-
-            track_api_request_task.run(
-                distinct_id="user-1",
-                event="public_api_request",
-                properties={"accessed_entity_id": 99, "entity_type": "recitation"},
-            )
-
         sent_props = client.track.call_args[0][2]
-        assert sent_props["accessed_entity_name"] == "Hafs An Asim"
+        assert sent_props["accessed_entity_name"] == "Ibn Kathir"
 
     @patch("apps.usage_tracking.tasks._build_ingest_client")
-    def test_task_accessed_entity_name_none_when_not_found(self, mock_build):
+    def test_task_does_not_touch_db_for_entity_name(self, mock_build):
+        """Celery task must make zero DB queries - connection exhaustion fix."""
         client = MagicMock()
         mock_build.return_value = client
 
-        with patch("apps.content.models.Asset.objects") as mock_qs:
-            mock_qs.filter.return_value.values.return_value.first.return_value = None
-
+        with patch("apps.content.models.Asset") as mock_asset:
             track_api_request_task.run(
-                distinct_id="user-1",
+                distinct_id="app-7",
                 event="public_api_request",
                 properties={"accessed_entity_id": 99},
             )
-
-        sent_props = client.track.call_args[0][2]
-        assert sent_props["accessed_entity_name"] is None
+            mock_asset.objects.filter.assert_not_called()

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -55,7 +55,13 @@ CORS_ALLOWED_ORIGINS = [
 settings.DATABASES["default"].update(
     {
         "ENGINE": "django.db.backends.postgresql",
-        "CONN_MAX_AGE": 60,
+        # Route through DO managed PgBouncer pool (transaction mode).
+        # CONN_MAX_AGE=0: Django must not hold persistent connections; the pool owns reuse.
+        # DISABLE_SERVER_SIDE_CURSORS: required for PgBouncer transaction mode.
+        "HOST": config("DB_POOL_HOST", default=config("DB_HOST", default="localhost")),
+        "PORT": config("DB_POOL_PORT", default=config("DB_PORT", default="5432")),
+        "CONN_MAX_AGE": 0,
+        "DISABLE_SERVER_SIDE_CURSORS": True,
         "OPTIONS": {
             "sslmode": "require",
             "connect_timeout": 10,


### PR DESCRIPTION
## Problem

Sentry issue CMS-BACKEND-1A: `OperationalError: remaining connection slots are reserved for roles with the SUPERUSER attribute`

Every API call to `/recitations/{id}/` or `/reciters/{id}/` spawned a Celery task that opened a DB connection to look up the entity name. Under burst traffic, concurrent workers exhausted `max_connections` on the DO Managed Postgres cluster.

## Changes

### Remove DB query from Celery task (`tasks.py`)
`track_api_request_task` was calling `Asset.objects.filter(pk=accessed_entity_id)` to resolve the entity name. This query is redundant - the entity name is already available in the API response body. The task now makes zero DB queries.

### Pass `accessed_entity_name` from middleware (`usage_tracking_middleware.py`)
The middleware already extracts entity names from the response body via `extract_entities()`. Added `accessed_entity_name = entity_names[0]` for single-entity endpoints (list endpoints get `None`). Passed in `properties` to the task.

### PgBouncer via DO managed pool (`production.py`)
- `DB_POOL_HOST` / `DB_POOL_PORT` env vars route traffic through the DO managed PgBouncer pool (port 25061) instead of the direct DB connection (port 25060)
- `CONN_MAX_AGE=0`: Django must not hold persistent connections; the pool owns reuse
- `DISABLE_SERVER_SIDE_CURSORS=True`: required for PgBouncer transaction mode

Pool `cms-pgbouncer` already created on `cms-production-db` cluster (transaction mode, size 47). Env vars already set on production server.

## Tests

- Removed old DB-query test cases from `test_tasks.py`
- Added regression test asserting `Asset.objects.filter` is never called in the task
- Added middleware tests for `accessed_entity_name` extraction (detail vs list endpoints)