### PR TITLE
chore(ci): setup versioning pipeline

### DIFF
--- a/.agents/rules/cms-backend.mdc
+++ b/.agents/rules/cms-backend.mdc
@@ -164,6 +164,19 @@ Each app has its own `api/` directory with subdirectories per API surface (`inte
 
 - All queries in `api/tenant` should be filtered for publisher, preferably using `request.publisher_q()`
 
+## Versioning
+- **Tool**: `commitizen` (configured in `pyproject.toml` under `[tool.commitizen]`)
+- **Version source**: `pyproject.toml` → `[project] version`
+- **Tag format**: `v{version}` (e.g. `v0.2.0`)
+- **Commit convention**: Conventional Commits enforced via pre-commit `commit-msg` hook and `commitlint.yml` CI workflow
+  - `feat:` → bumps MINOR
+  - `fix:` / `perf:` → bumps PATCH
+  - `BREAKING CHANGE:` footer → bumps MAJOR
+- **Bump command**: `cz bump --yes` (run by `version-bump.yml` on push to `main`)
+- **Changelog**: auto-generated at `CHANGELOG.md` by `cz bump`; release-branch scaffold via `changelog.yml`
+- **Sentry releases**: created automatically by `version-bump.yml` using org `itqan-3o`, project `cms-backend` / `cms-backend-staging`
+- **Release branches**: named `release/v{version}` (e.g. `release/v1.0.0`); pushing to one triggers `changelog.yml`
+
 ## General
 - **Dependency management**: Use `uv` (`uv sync` to install, `uv sync --group dev` for dev dependencies)
 - **Linting**: Use `pre-commit install` to set up Git hooks. All PRs must pass linting checks to be merged

--- a/.github/scripts/update-changelog.py
+++ b/.github/scripts/update-changelog.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import os
+import re
+
+version = os.environ["SEMVER"]
+ai_notes = open("/tmp/ai-release-notes.txt").read().strip()  # nosec B108
+changelog = "CHANGELOG.md"
+
+with open(changelog) as f:
+    content = f.read()
+
+ai_block = f"### AI Summary\n\n{ai_notes}\n\n### Commits\n\n"
+content = re.sub(
+    rf"(## {re.escape(version)}[^\n]*\n\n)",
+    rf"\g<1>{ai_block}",
+    content,
+    count=1,
+)
+
+with open(changelog, "w") as f:
+    f.write(content)
+
+print(f"CHANGELOG.md updated with AI summary for {version}")

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,48 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - 'release/v*'
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install commitizen
+        run: pip install commitizen==4.10.*
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          VERSION=$(echo "$GITHUB_REF_NAME" | sed 's|release/v||')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog entry
+        run: cz changelog --unreleased-version "v${{ steps.version.outputs.version }}"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push changelog
+        run: |
+          git add CHANGELOG.md
+          git diff --cached --quiet && echo "No changelog changes" && exit 0
+          git commit -m "docs(changelog): entry for v${{ steps.version.outputs.version }} [skip ci]"
+          git push origin "$GITHUB_REF_NAME"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,25 @@
+name: Commitlint
+
+on:
+  pull_request:
+    branches: [staging, main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install commitizen
+        run: pip install commitizen==4.10.*
+
+      - name: Check commit messages
+        run: cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,136 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install commitizen and sentry-cli
+        run: |
+          pip install commitizen==4.10.*
+          npm install -g @sentry/cli
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump
+        run: |
+          if cz bump --yes 2>&1; then
+            echo "bumped=true" >> $GITHUB_OUTPUT
+            echo "version=$(python3 -c "import tomllib; f=open('pyproject.toml','rb'); d=tomllib.load(f); print(d['project']['version'])")" >> $GITHUB_OUTPUT
+          else
+            echo "bumped=false" >> $GITHUB_OUTPUT
+            echo "No releasable commits found, skipping."
+          fi
+
+      - name: Generate AI release notes and update CHANGELOG
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          export SEMVER="${{ steps.bump.outputs.version }}"
+
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log "${PREV_TAG}..HEAD" --format="- %s" --no-merges 2>/dev/null)
+          else
+            COMMITS=$(git log --format="- %s" --no-merges --max-count=50 2>/dev/null)
+          fi
+
+          AI_NOTES=""
+          if [ -n "$COMMITS" ] && [ -n "$GEMINI_API_KEY" ]; then
+            PROMPT="You are a technical writer for an open-source Islamic/Quranic content management platform. Write concise release notes for version ${SEMVER} based on these git commits:\n\n${COMMITS}\n\nFormat: 1-2 sentence summary, then ## What's New, ## Bug Fixes, ## Breaking Changes (only if relevant). Be specific. Plain language. No filler."
+            RESPONSE=$(curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg text "$PROMPT" '{
+                contents: [{ parts: [{ text: $text }] }],
+                generationConfig: { maxOutputTokens: 1024, temperature: 0.3 }
+              }')")
+            AI_NOTES=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text // empty' 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$AI_NOTES" ]; then
+            AI_NOTES="Release v${SEMVER}. See commit history for full details."
+          fi
+
+          echo "$AI_NOTES" > /tmp/ai-release-notes.txt
+          echo "AI release notes saved."
+
+          python3 .github/scripts/update-changelog.py
+
+          git add CHANGELOG.md
+          git commit --amend --no-edit
+          git tag -f -a "v${SEMVER}" -m "v${SEMVER}"
+
+      - name: Push version bump commit and tag
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git push origin main --follow-tags
+
+      - name: Create GitHub Release with AI notes
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.bump.outputs.version }}"
+          AI_NOTES=$(cat /tmp/ai-release-notes.txt 2>/dev/null || echo "See commit history for details.")
+          gh release create "$VERSION" --title "$VERSION" --notes "$AI_NOTES"
+
+      - name: Create Sentry release
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: itqan-3o
+          SENTRY_PROJECT: cms-backend
+        run: |
+          VERSION="v${{ steps.bump.outputs.version }}"
+          sentry-cli releases new "$VERSION"
+          sentry-cli releases set-commits "$VERSION" --auto
+          sentry-cli releases finalize "$VERSION"
+
+      - name: Post release to Slack
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK not set, skipping"
+            exit 0
+          fi
+          VERSION="v${{ steps.bump.outputs.version }}"
+          AI_NOTES=$(cat /tmp/ai-release-notes.txt 2>/dev/null | head -c 500)
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg version "$VERSION" \
+              --arg notes "$AI_NOTES" \
+              --arg repo "$GITHUB_REPOSITORY" \
+              '{
+                blocks: [{
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: (":rocket: *CMS Backend " + $version + " Released*\n\n" + $notes + "\n\n<https://github.com/" + $repo + "/releases/tag/" + $version + "|View Release Notes>")
+                  }
+                }]
+              }')"

--- a/.gitignore
+++ b/.gitignore
@@ -342,6 +342,7 @@ media/
 .claude/
 /temp/*
 /CLAUDE.md
+scripts/.mixpanel_traffic.env
 
 # Docusaurus
 docs-website/build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: '^docs/|/migrations/|devcontainer.json'
 default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, commit-msg]
 minimum_pre_commit_version: "3.2.0"
 
 default_language_version:
@@ -58,3 +59,9 @@ repos:
     hooks:
       - id: django-upgrade
         args: ['--target-version', '5.2']
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.10.1
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "commitizen==4.10.*",
     "boto3-stubs>=1.42.91",
     "coverage==7.10.6",
     "django-coverage-plugin==3.1.1",
@@ -200,3 +201,14 @@ omit = [
 [tool.coverage.report]
 skip_covered = true
 show_missing = true
+
+# ========================
+# Commitizen
+# ========================
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version_provider = "pep621"
+tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Adds `commitizen` config to `pyproject.toml` for conventional commit enforcement and auto version bumping
- Adds `commitizen` commit-msg hook to `.pre-commit-config.yaml`
- Adds `commitlint.yml` CI workflow — rejects non-conventional commit messages on PRs to `staging`/`main`
- Adds `version-bump.yml` — on push to `main`: bumps version, generates AI release notes via Gemini, updates CHANGELOG.md, creates GitHub Release, Sentry release, and Slack notification
- Adds `changelog.yml` — scaffolds CHANGELOG entries on `release/v*` branches

## Secrets needed
- `GEMINI_API_KEY` — already added
- `SLACK_DEPLOY_WEBHOOK` — already set (used by existing ci-cd.yml)
- `SENTRY_AUTH_TOKEN` — confirm present in repo settings

## Test plan
- [ ] Merge this PR → `version-bump.yml` runs automatically (existing `fix:` commits in history trigger `0.1.0 → 0.1.1`)
- [ ] Verify `pyproject.toml` version bumped, tag `v0.1.1` created, CHANGELOG.md generated, GitHub Release created
- [ ] Verify Sentry release visible in `cms-backend` project
- [ ] Verify Slack notification posted