### PR TITLE
toggle auto_accept_access_requests of publisher from portal

### DIFF
--- a/apps/publishers/api/portal/publishers.py
+++ b/apps/publishers/api/portal/publishers.py
@@ -158,6 +158,7 @@ class PublisherDetailOut(Schema):
     is_verified: bool
     foundation_year: int | None
     country: str
+    auto_accept_access_requests: bool
     icon_url: str | None = None
     created_at: AwareDatetime
     updated_at: AwareDatetime
@@ -199,6 +200,7 @@ class PublisherPatchIn(Schema):
     is_verified: bool | None = None
     foundation_year: int | None = None
     country: str | None = None
+    auto_accept_access_requests: bool | None = None
 
 
 class PublisherPutIn(Schema):
@@ -212,6 +214,7 @@ class PublisherPutIn(Schema):
     is_verified: bool = True
     foundation_year: int | None = None
     country: str = ""
+    auto_accept_access_requests: bool = True
 
 
 @router.put(

--- a/apps/publishers/tests/portal/test_update_publisher.py
+++ b/apps/publishers/tests/portal/test_update_publisher.py
@@ -52,6 +52,25 @@ class UpdatePublisherTest(BaseTestCase):
         self.assertEqual(2020, body["foundation_year"])
         self.assertEqual("Saudi Arabia", body["country"])
 
+    def test_put_publisher_where_auto_accept_access_requests_set_should_persist(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        self.give_permission(self.user, PermissionChoice.PORTAL_UPDATE_PUBLISHER)
+        data = {
+            "name_en": "Updated Publisher",
+            "auto_accept_access_requests": False,
+        }
+
+        # Act
+        response = self.client.put(self.url, data, format="multipart")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertFalse(body["auto_accept_access_requests"])
+        self.publisher.refresh_from_db()
+        self.assertFalse(self.publisher.auto_accept_access_requests)
+
     def test_put_publisher_where_not_found_should_return_404(self) -> None:
         # Arrange
         self.authenticate_user(self.user)
@@ -113,6 +132,24 @@ class UpdatePublisherTest(BaseTestCase):
         body = response.json()
         self.assertEqual("الناشر المحدث", body["name_ar"])
         self.assertEqual("وصف محدث", body["description_ar"])
+
+    def test_patch_publisher_where_auto_accept_access_requests_set_should_persist(self) -> None:
+        # Arrange
+        self.authenticate_user(self.user)
+        self.give_permission(self.user, PermissionChoice.PORTAL_UPDATE_PUBLISHER)
+        self.publisher.auto_accept_access_requests = True
+        self.publisher.save(update_fields=["auto_accept_access_requests"])
+        data = {"auto_accept_access_requests": False}
+
+        # Act
+        response = self.client.patch(self.url, data, format="multipart")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertFalse(body["auto_accept_access_requests"])
+        self.publisher.refresh_from_db()
+        self.assertFalse(self.publisher.auto_accept_access_requests)
 
     def test_patch_publisher_where_icon_provided_should_return_200(self) -> None:
         # Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publisher details now include an `auto_accept_access_requests` setting.
  * Publisher updates support changing this setting through both full and partial updates.

* **Bug Fixes**
  * Improved update handling so changes to `auto_accept_access_requests` are returned correctly and saved consistently.

* **Tests**
  * Added coverage for updating the new setting via both update flows and verifying it persists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->