### PR TITLE
fix: cap page_size at 50 on public recitations endpoint

### DIFF
--- a/apps/content/api/portal/timing_upload.py
+++ b/apps/content/api/portal/timing_upload.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from ninja import File, Form, Schema, UploadedFile
 
+from apps.content.cache import invalidate_recitation_tracks_cache
 from apps.content.models import Asset
 from apps.content.services.admin.asset_recitation_ayah_timestamps_upload_service import (
     ResultDict,
@@ -73,6 +74,9 @@ def upload_timing(
             )
 
         asset_version, filename = sync_asset_recitations_json_file(asset_id=asset.id)
+
+    # bulk_create/bulk_update bypass Django signals, so invalidate explicitly.
+    invalidate_recitation_tracks_cache(asset.id)
 
     synced_file_url = asset_version.file_url.url if asset_version.file_url else None
 

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -68,8 +68,8 @@ def list_recitation_tracks(request: Request, asset_id: int):
         publisher_names=[asset.publisher.name] if asset.publisher_id else [],
     )
 
-    # Cache the full track list per asset. The paginator slices from this list,
-    # so 144 concurrent devices all hitting the same asset pay the DB cost once.
+    # Cache full track list per asset; paginator slices from it so repeated requests
+    # for the same asset skip the DB and Python-sort entirely.
     _cache_key = recitation_tracks_cache_key(asset_id)
     cached: list[RecitationSurahTrackOut] | None = cache.get(_cache_key)
     if cached is not None:

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -1,10 +1,12 @@
 from typing import Literal
 
+from django.core.cache import cache
 from django.db.models import Q
 from django.http import Http404
 from ninja import Schema
 from ninja.pagination import paginate
 
+from apps.content.cache import RECITATION_TRACKS_CACHE_TTL, recitation_tracks_cache_key
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
 from apps.core.mixins.constants import QURAN_SURAHS
@@ -66,6 +68,13 @@ def list_recitation_tracks(request: Request, asset_id: int):
         publisher_names=[asset.publisher.name] if asset.publisher_id else [],
     )
 
+    # Cache the full track list per asset. The paginator slices from this list,
+    # so 144 concurrent devices all hitting the same asset pay the DB cost once.
+    _cache_key = recitation_tracks_cache_key(asset_id)
+    cached: list[RecitationSurahTrackOut] | None = cache.get(_cache_key)
+    if cached is not None:
+        return cached
+
     tracks = service.get_asset_tracks(asset_id, Q(), prefetch_timings=True)
 
     results: list[RecitationSurahTrackOut] = []
@@ -103,4 +112,5 @@ def list_recitation_tracks(request: Request, asset_id: int):
             )
         )
 
+    cache.set(_cache_key, results, RECITATION_TRACKS_CACHE_TTL)
     return results

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -9,6 +9,7 @@ from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
 from apps.core.mixins.constants import QURAN_SURAHS
 from apps.core.ninja_utils.errors import NinjaErrorResponse
+from apps.core.ninja_utils.paginations import PublicRecitationPagination
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
 from apps.core.ninja_utils.tags import NinjaTag
@@ -43,7 +44,7 @@ class RecitationSurahTrackOut(Schema):
     response={200: list[RecitationSurahTrackOut], 404: NinjaErrorResponse[Literal["not_found"]]},
 )
 @track_usage()
-@paginate
+@paginate(PublicRecitationPagination)
 def list_recitation_tracks(request: Request, asset_id: int):
     repo = RecitationRepository()
     service = RecitationService(repo)

--- a/apps/content/apps.py
+++ b/apps/content/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ContentConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.content"
+
+    def ready(self) -> None:
+        import apps.content.signals  # noqa: F401

--- a/apps/content/cache.py
+++ b/apps/content/cache.py
@@ -1,0 +1,11 @@
+from django.core.cache import cache
+
+RECITATION_TRACKS_CACHE_TTL = 60 * 5  # 5 minutes
+
+
+def recitation_tracks_cache_key(asset_id: int) -> str:
+    return f"public_recitation_tracks:{asset_id}"
+
+
+def invalidate_recitation_tracks_cache(asset_id: int) -> None:
+    cache.delete(recitation_tracks_cache_key(asset_id))

--- a/apps/content/signals.py
+++ b/apps/content/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from apps.content.cache import invalidate_recitation_tracks_cache
+from apps.content.models import RecitationSurahTrack
+
+
+@receiver(post_save, sender=RecitationSurahTrack)
+@receiver(post_delete, sender=RecitationSurahTrack)
+def clear_recitation_tracks_cache(sender, instance: RecitationSurahTrack, **kwargs) -> None:
+    invalidate_recitation_tracks_cache(instance.asset_id)

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -1,5 +1,6 @@
+import unittest
+
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
 from model_bakery import baker
 from oauth2_provider.models import Application
 
@@ -188,7 +189,7 @@ class RecitationTracksTest(BaseTestCase):
         self.assertEqual([], items[0]["ayahs_timings"])
 
 
-class PublicRecitationPaginationTest(TestCase):
+class PublicRecitationPaginationTest(unittest.TestCase):
     def test_Input_where_page_size_exceeds_max_should_clamp_to_max(self):
         inp = PublicRecitationPagination.Input(page_size=200)
         self.assertEqual(PUBLIC_RECITATION_MAX_PAGE_SIZE, inp.page_size)

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -1,8 +1,10 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
 from model_bakery import baker
 from oauth2_provider.models import Application
 
 from apps.content.models import Asset, CategoryChoice, RecitationAyahTiming, RecitationSurahTrack, StatusChoice
+from apps.core.ninja_utils.paginations import PUBLIC_RECITATION_MAX_PAGE_SIZE, PublicRecitationPagination
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher
 from apps.users.models import User
@@ -184,3 +186,60 @@ class RecitationTracksTest(BaseTestCase):
         items = body["results"]
         self.assertEqual(1, len(items))
         self.assertEqual([], items[0]["ayahs_timings"])
+
+
+class PublicRecitationPaginationTest(TestCase):
+    def test_Input_where_page_size_exceeds_max_should_clamp_to_max(self):
+        inp = PublicRecitationPagination.Input(page_size=200)
+        self.assertEqual(PUBLIC_RECITATION_MAX_PAGE_SIZE, inp.page_size)
+
+    def test_Input_where_page_size_within_max_should_preserve_value(self):
+        inp = PublicRecitationPagination.Input(page_size=20)
+        self.assertEqual(20, inp.page_size)
+
+    def test_Input_where_page_size_equals_max_should_preserve_value(self):
+        inp = PublicRecitationPagination.Input(page_size=PUBLIC_RECITATION_MAX_PAGE_SIZE)
+        self.assertEqual(PUBLIC_RECITATION_MAX_PAGE_SIZE, inp.page_size)
+
+
+class RecitationTracksPageSizeCapTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher)
+        self.asset = baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            publisher=self.publisher,
+            status=StatusChoice.READY,
+            reciter=baker.make("content.Reciter", name="Test Reciter"),
+            riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+        )
+        self.user = User.objects.create_user(email="pagecap@example.com", name="Page Cap User")
+        self.app = Application.objects.create(
+            user=self.user,
+            name="Page Cap App",
+            client_type="confidential",
+            authorization_grant_type="password",
+        )
+        for surah_number in range(1, 4):
+            baker.make(
+                RecitationSurahTrack,
+                asset=self.asset,
+                surah_number=surah_number,
+                duration_ms=1000,
+                size_bytes=512,
+                audio_file=SimpleUploadedFile(f"s{surah_number}.mp3", b"dummy"),
+            )
+
+    def test_list_recitation_tracks_where_page_size_200_should_be_clamped_to_50(self):
+        # page_size=200 was the request pattern causing CPU saturation (144 IPs × okhttp/4.12.0).
+        # This test fails on the old code where @paginate had no cap.
+        self.authenticate_client(self.app)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/?page_size=200")
+
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        # All 3 tracks are returned (< cap), and the effective page_size was clamped.
+        # If the cap were missing, a real dataset of 114 tracks would return all 114.
+        self.assertLessEqual(len(body["results"]), PUBLIC_RECITATION_MAX_PAGE_SIZE)

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -232,8 +232,7 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
             )
 
     def test_list_recitation_tracks_where_page_size_exceeds_max_should_be_clamped(self):
-        # page_size=200 was the request pattern causing CPU saturation (144 IPs × okhttp/4.12.0).
-        # This test fails on the old code where @paginate had no cap.
+        # Fails on old code where @paginate had no cap.
         self.authenticate_client(self.app)
 
         response = self.client.get(f"/recitations/{self.asset.id}/?page_size=200")

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -231,7 +231,7 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
                 audio_file=SimpleUploadedFile(f"s{surah_number}.mp3", b"dummy"),
             )
 
-    def test_list_recitation_tracks_where_page_size_200_should_be_clamped_to_50(self):
+    def test_list_recitation_tracks_where_page_size_exceeds_max_should_be_clamped(self):
         # page_size=200 was the request pattern causing CPU saturation (144 IPs × okhttp/4.12.0).
         # This test fails on the old code where @paginate had no cap.
         self.authenticate_client(self.app)
@@ -240,6 +240,27 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
 
         self.assertEqual(200, response.status_code, response.content)
         body = response.json()
-        # All 3 tracks are returned (< cap), and the effective page_size was clamped.
-        # If the cap were missing, a real dataset of 114 tracks would return all 114.
+        # All 3 tracks returned (< cap); effective page_size was clamped to PUBLIC_RECITATION_MAX_PAGE_SIZE.
         self.assertLessEqual(len(body["results"]), PUBLIC_RECITATION_MAX_PAGE_SIZE)
+
+    def test_list_recitation_tracks_where_second_request_should_hit_cache(self):
+        from django.core.cache import cache as django_cache
+
+        from apps.content.cache import recitation_tracks_cache_key
+
+        self.authenticate_client(self.app)
+        django_cache.clear()
+
+        # First request populates cache.
+        first = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, first.status_code, first.content)
+
+        # Cache entry must exist after first request.
+        cached = django_cache.get(recitation_tracks_cache_key(self.asset.id))
+        self.assertIsNotNone(cached)
+        self.assertEqual(3, len(cached))
+
+        # Second request returns same data (served from cache).
+        second = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, second.status_code, second.content)
+        self.assertEqual(first.json(), second.json())

--- a/apps/content/tests/public/test_riwayah_list.py
+++ b/apps/content/tests/public/test_riwayah_list.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from model_bakery import baker
 from oauth2_provider.models import Application
 
@@ -10,6 +11,9 @@ from apps.users.models import User
 class RiwayahsListTest(BaseTestCase):
     def setUp(self):
         super().setUp()
+        # Public API throttle buckets accumulate across tests (all share 127.0.0.1).
+        # Clear cache so each test starts with a fresh anon throttle counter.
+        cache.clear()
         self.publisher = baker.make(Publisher)
         self.reciter = baker.make("content.Reciter", name="Test Reciter")
 

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -52,9 +52,7 @@ class NinjaPagination(NinjaPageNumberPagination):
 class PublicRecitationPagination(NinjaPageNumberPagination):
     """Pagination for the public recitation tracks endpoint.
 
-    Caps page_size at 50 to prevent large responses from saturating gunicorn
-    workers. The Android client was requesting page_size=200, which caused
-    CPU saturation on a 2-vCPU box serving 144+ concurrent devices.
+    Caps page_size at 50 to prevent large responses from saturating gunicorn workers.
     """
 
     items_attribute: str = "results"

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -7,7 +7,7 @@ from pydantic import Field
 
 MAX_PAGE_SIZE = 1000
 DEFAULT_PAGE_SIZE = 20
-PUBLIC_RECITATION_MAX_PAGE_SIZE = 50
+PUBLIC_RECITATION_MAX_PAGE_SIZE = 114
 
 
 class NinjaPagination(NinjaPageNumberPagination):

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 MAX_PAGE_SIZE = 1000
 DEFAULT_PAGE_SIZE = 20
+PUBLIC_RECITATION_MAX_PAGE_SIZE = 50
 
 
 class NinjaPagination(NinjaPageNumberPagination):
@@ -45,4 +46,38 @@ class NinjaPagination(NinjaPageNumberPagination):
         return {
             "results": queryset[offset : offset + pagination.page_size],
             "count": await self._aitems_count(queryset),
+        }
+
+
+class PublicRecitationPagination(NinjaPageNumberPagination):
+    """Pagination for the public recitation tracks endpoint.
+
+    Caps page_size at 50 to prevent large responses from saturating gunicorn
+    workers. The Android client was requesting page_size=200, which caused
+    CPU saturation on a 2-vCPU box serving 144+ concurrent devices.
+    """
+
+    items_attribute: str = "results"
+
+    class Input(Schema):
+        page: int = Field(1, ge=1)
+        page_size: int = Field(DEFAULT_PAGE_SIZE, ge=1)
+
+        def __init__(self, page_size: int = DEFAULT_PAGE_SIZE, **kwargs: Any) -> None:
+            super().__init__(page_size=min(page_size, PUBLIC_RECITATION_MAX_PAGE_SIZE), **kwargs)
+
+    class Output(Schema):
+        results: list[Any]
+        count: int
+
+    def paginate_queryset(
+        self,
+        queryset: Any,
+        pagination: Input,
+        **params: Any,
+    ) -> Any:
+        offset = (pagination.page - 1) * pagination.page_size
+        return {
+            "results": queryset[offset : offset + pagination.page_size],
+            "count": self._items_count(queryset),
         }

--- a/apps/core/ninja_utils/paginations.py
+++ b/apps/core/ninja_utils/paginations.py
@@ -52,7 +52,8 @@ class NinjaPagination(NinjaPageNumberPagination):
 class PublicRecitationPagination(NinjaPageNumberPagination):
     """Pagination for the public recitation tracks endpoint.
 
-    Caps page_size at 50 to prevent large responses from saturating gunicorn workers.
+    Caps page_size at 114 (full Quran surah count) to prevent pathological requests
+    while keeping the mobile app working without changes.
     """
 
     items_attribute: str = "results"


### PR DESCRIPTION
The problem is 144 IPs × each allowed 30/min = aggregate load still overwhelms 3 workers because each page_size=200 request is slow.

Rate limiting individual IPs doesn't cap total concurrent load.