### PR TITLE
perf: pre-serialized response cache for /recitations endpoint

### DIFF
--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -54,7 +54,7 @@ class RecitationSurahTrackOut(Schema):
 def list_recitation_tracks(
     request: Request,
     asset_id: int,
-    page: int = Query(1, ge=1, le=100),
+    page: int = Query(1, ge=1, le=114),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1),
 ):
     page_size = min(page_size, PUBLIC_RECITATION_MAX_PAGE_SIZE)

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -54,7 +54,7 @@ class RecitationSurahTrackOut(Schema):
 def list_recitation_tracks(
     request: Request,
     asset_id: int,
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=100),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1),
 ):
     page_size = min(page_size, PUBLIC_RECITATION_MAX_PAGE_SIZE)
@@ -143,7 +143,9 @@ def list_recitation_tracks(
 
     response_bytes = json.dumps({"results": paginated, "count": total}).encode()
 
-    cache.set(_resp_key, response_bytes, RECITATION_RESPONSE_CACHE_TTL)
+    if offset < total:
+        # Only cache pages that have content; out-of-range pages are not worth storing.
+        cache.set(_resp_key, response_bytes, RECITATION_RESPONSE_CACHE_TTL)
     cache.set(_meta_key, asset_meta, RECITATION_ASSET_META_CACHE_TTL)
 
     resp = HttpResponse(response_bytes, content_type="application/json")

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -1,22 +1,22 @@
+import json
 from typing import Literal
 
 from django.core.cache import cache
 from django.db.models import Q
-from django.http import Http404
-from ninja import Schema
-from ninja.pagination import paginate
+from django.http import Http404, HttpResponse
+from ninja import Query, Schema
 
 from apps.content.cache import (
     RECITATION_ASSET_META_CACHE_TTL,
-    RECITATION_TRACKS_CACHE_TTL,
+    RECITATION_RESPONSE_CACHE_TTL,
     recitation_asset_meta_cache_key,
-    recitation_tracks_cache_key,
+    recitation_response_cache_key,
 )
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
 from apps.core.mixins.constants import QURAN_SURAHS
 from apps.core.ninja_utils.errors import NinjaErrorResponse
-from apps.core.ninja_utils.paginations import PublicRecitationPagination
+from apps.core.ninja_utils.paginations import DEFAULT_PAGE_SIZE, PUBLIC_RECITATION_MAX_PAGE_SIZE
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
 from apps.core.ninja_utils.tags import NinjaTag
@@ -51,16 +51,21 @@ class RecitationSurahTrackOut(Schema):
     response={200: list[RecitationSurahTrackOut], 404: NinjaErrorResponse[Literal["not_found"]]},
 )
 @track_usage()
-@paginate(PublicRecitationPagination)
-def list_recitation_tracks(request: Request, asset_id: int):
-    _tracks_key = recitation_tracks_cache_key(asset_id)
+def list_recitation_tracks(
+    request: Request,
+    asset_id: int,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1),
+):
+    page_size = min(page_size, PUBLIC_RECITATION_MAX_PAGE_SIZE)
+
+    _resp_key = recitation_response_cache_key(asset_id, page, page_size)
     _meta_key = recitation_asset_meta_cache_key(asset_id)
 
-    cached_tracks: list[RecitationSurahTrackOut] | None = cache.get(_tracks_key)
+    cached_resp: bytes | None = cache.get(_resp_key)
     cached_meta: dict | None = cache.get(_meta_key)
 
-    if cached_tracks is not None and cached_meta is not None:
-        # Full cache hit - no DB, no repo construction.
+    if cached_resp is not None and cached_meta is not None:
         track_extra(
             request,
             entity_type="recitation",
@@ -70,15 +75,16 @@ def list_recitation_tracks(request: Request, asset_id: int):
             publisher_ids=[cached_meta["publisher_id"]] if cached_meta["publisher_id"] else [],
             publisher_names=[cached_meta["publisher_name"]] if cached_meta["publisher_id"] else [],
         )
-        return cached_tracks
+        resp = HttpResponse(cached_resp, content_type="application/json")
+        resp["Cache-Control"] = "public, max-age=300, s-maxage=300"
+        return resp
 
-    # Cache miss (or meta expired) - hit the DB.
+    # Cache miss - hit DB.
     repo = RecitationRepository()
     service = RecitationService(repo)
 
     asset = repo.get_asset_object(asset_id, Q())
     if not asset:
-        # 404s raise before track_extra, so the decorator dispatches nothing for them.
         raise Http404("No asset matches the given query.")
 
     publisher_name = asset.publisher.name if asset.publisher_id else None
@@ -98,48 +104,48 @@ def list_recitation_tracks(request: Request, asset_id: int):
         publisher_names=[publisher_name] if asset.publisher_id else [],
     )
 
-    if cached_tracks is not None:
-        # Tracks cached but meta expired - repopulate meta and return.
-        cache.set(_meta_key, asset_meta, RECITATION_ASSET_META_CACHE_TTL)
-        return cached_tracks
-
     tracks = service.get_asset_tracks(asset_id, Q(), prefetch_timings=True)
 
-    results: list[RecitationSurahTrackOut] = []
-
+    all_results = []
     for track in tracks:
         audio_url = f"{CLOUDFLARE_R2_PUBLIC_BASE_URL}/media/{track.audio_file.name}"
-
-        ayah_timings: list[RecitationAyahTimingOut] = []
-        sorted_ayah_timings_qs = sorted(
+        surah = QURAN_SURAHS[track.surah_number]
+        sorted_timings = sorted(
             track.ayah_timings.all(),
             key=lambda a: (int(a.ayah_key.split(":")[0]), int(a.ayah_key.split(":")[1])),
         )
-        for t in sorted_ayah_timings_qs:
-            ayah_timings.append(
-                RecitationAyahTimingOut(
-                    ayah_key=t.ayah_key,
-                    start_ms=t.start_ms,
-                    end_ms=t.end_ms,
-                    duration_ms=t.duration_ms,
-                )
-            )
-
-        results.append(
-            RecitationSurahTrackOut(
-                surah_number=track.surah_number,
-                surah_name=QURAN_SURAHS[track.surah_number]["name"],
-                surah_name_en=QURAN_SURAHS[track.surah_number]["name_en"],
-                audio_url=audio_url,
-                duration_ms=track.duration_ms,
-                size_bytes=track.size_bytes,
-                revelation_order=QURAN_SURAHS[track.surah_number]["revelation_order"],
-                revelation_place=QURAN_SURAHS[track.surah_number]["revelation_place"],
-                ayahs_count=QURAN_SURAHS[track.surah_number]["ayahs_count"],
-                ayahs_timings=ayah_timings,
-            )
+        all_results.append(
+            {
+                "surah_number": track.surah_number,
+                "surah_name": surah["name"],
+                "surah_name_en": surah["name_en"],
+                "audio_url": audio_url,
+                "duration_ms": track.duration_ms,
+                "size_bytes": track.size_bytes,
+                "revelation_order": surah["revelation_order"],
+                "revelation_place": surah["revelation_place"],
+                "ayahs_count": surah["ayahs_count"],
+                "ayahs_timings": [
+                    {
+                        "ayah_key": t.ayah_key,
+                        "start_ms": t.start_ms,
+                        "end_ms": t.end_ms,
+                        "duration_ms": t.duration_ms,
+                    }
+                    for t in sorted_timings
+                ],
+            }
         )
 
-    cache.set(_tracks_key, results, RECITATION_TRACKS_CACHE_TTL)
+    total = len(all_results)
+    offset = (page - 1) * page_size
+    paginated = all_results[offset : offset + page_size]
+
+    response_bytes = json.dumps({"results": paginated, "count": total}).encode()
+
+    cache.set(_resp_key, response_bytes, RECITATION_RESPONSE_CACHE_TTL)
     cache.set(_meta_key, asset_meta, RECITATION_ASSET_META_CACHE_TTL)
-    return results
+
+    resp = HttpResponse(response_bytes, content_type="application/json")
+    resp["Cache-Control"] = "public, max-age=300, s-maxage=300"
+    return resp

--- a/apps/content/cache.py
+++ b/apps/content/cache.py
@@ -18,14 +18,13 @@ def recitation_response_cache_key(asset_id: int, page: int, page_size: int) -> s
 
 
 def invalidate_recitation_tracks_cache(asset_id: int) -> None:
+    # Deleting meta is sufficient: the view requires both resp AND meta for a cache hit,
+    # so clearing meta forces a full DB rebuild on the next request. Stale resp bytes
+    # for any (page, page_size) variant are overwritten on that rebuild and expire
+    # naturally within RECITATION_RESPONSE_CACHE_TTL (5 min) for untouched variants.
     cache.delete_many(
         [
             recitation_tracks_cache_key(asset_id),
             recitation_asset_meta_cache_key(asset_id),
         ]
     )
-    # Also wipe pre-serialized response keys for this asset (page/page_size vary, use pattern).
-    try:
-        cache.delete_pattern(f"*:public_recitation_resp:{asset_id}:*")
-    except AttributeError:
-        pass  # non-Redis backend (e.g. locmem in tests)

--- a/apps/content/cache.py
+++ b/apps/content/cache.py
@@ -2,6 +2,7 @@ from django.core.cache import cache
 
 RECITATION_TRACKS_CACHE_TTL = 60 * 5  # 5 minutes
 RECITATION_ASSET_META_CACHE_TTL = 60 * 60  # 1 hour - asset name/publisher rarely changes
+RECITATION_RESPONSE_CACHE_TTL = 60 * 5  # 5 minutes
 
 
 def recitation_tracks_cache_key(asset_id: int) -> str:
@@ -12,5 +13,19 @@ def recitation_asset_meta_cache_key(asset_id: int) -> str:
     return f"public_recitation_asset_meta:{asset_id}"
 
 
+def recitation_response_cache_key(asset_id: int, page: int, page_size: int) -> str:
+    return f"public_recitation_resp:{asset_id}:{page}:{page_size}"
+
+
 def invalidate_recitation_tracks_cache(asset_id: int) -> None:
-    cache.delete_many([recitation_tracks_cache_key(asset_id), recitation_asset_meta_cache_key(asset_id)])
+    cache.delete_many(
+        [
+            recitation_tracks_cache_key(asset_id),
+            recitation_asset_meta_cache_key(asset_id),
+        ]
+    )
+    # Also wipe pre-serialized response keys for this asset (page/page_size vary, use pattern).
+    try:
+        cache.delete_pattern(f"*:public_recitation_resp:{asset_id}:*")
+    except AttributeError:
+        pass  # non-Redis backend (e.g. locmem in tests)

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -4,12 +4,12 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 from oauth2_provider.models import Application
 
-from apps.content.models import Asset, CategoryChoice, RecitationAyahTiming, RecitationSurahTrack, StatusChoice
 from apps.content.cache import recitation_response_cache_key
+from apps.content.models import Asset, CategoryChoice, RecitationAyahTiming, RecitationSurahTrack, StatusChoice
 from apps.core.ninja_utils.paginations import (
+    DEFAULT_PAGE_SIZE,
     PUBLIC_RECITATION_MAX_PAGE_SIZE,
     PublicRecitationPagination,
-    DEFAULT_PAGE_SIZE,
 )
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -5,7 +5,12 @@ from model_bakery import baker
 from oauth2_provider.models import Application
 
 from apps.content.models import Asset, CategoryChoice, RecitationAyahTiming, RecitationSurahTrack, StatusChoice
-from apps.core.ninja_utils.paginations import PUBLIC_RECITATION_MAX_PAGE_SIZE, PublicRecitationPagination
+from apps.content.cache import recitation_response_cache_key
+from apps.core.ninja_utils.paginations import (
+    PUBLIC_RECITATION_MAX_PAGE_SIZE,
+    PublicRecitationPagination,
+    DEFAULT_PAGE_SIZE,
+)
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher
 from apps.users.models import User
@@ -205,7 +210,10 @@ class PublicRecitationPaginationTest(unittest.TestCase):
 
 class RecitationTracksPageSizeCapTest(BaseTestCase):
     def setUp(self):
+        from django.core.cache import cache as django_cache
+
         super().setUp()
+        django_cache.clear()
         self.publisher = baker.make(Publisher)
         self.asset = baker.make(
             Asset,
@@ -244,9 +252,9 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
         self.assertLessEqual(len(body["results"]), PUBLIC_RECITATION_MAX_PAGE_SIZE)
 
     def test_list_recitation_tracks_where_second_request_should_hit_cache(self):
-        from django.core.cache import cache as django_cache
+        import json
 
-        from apps.content.cache import recitation_tracks_cache_key
+        from django.core.cache import cache as django_cache
 
         self.authenticate_client(self.app)
         django_cache.clear()
@@ -255,10 +263,13 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
         first = self.client.get(f"/recitations/{self.asset.id}/")
         self.assertEqual(200, first.status_code, first.content)
 
-        # Cache entry must exist after first request.
-        cached = django_cache.get(recitation_tracks_cache_key(self.asset.id))
-        self.assertIsNotNone(cached)
-        self.assertEqual(3, len(cached))
+        # Pre-serialized response bytes must exist after first request.
+        cached_bytes = django_cache.get(
+            recitation_response_cache_key(self.asset.id, page=1, page_size=DEFAULT_PAGE_SIZE)
+        )
+        self.assertIsNotNone(cached_bytes)
+        cached_data = json.loads(cached_bytes)
+        self.assertEqual(3, len(cached_data["results"]))
 
         # Second request returns same data (served from cache).
         second = self.client.get(f"/recitations/{self.asset.id}/")
@@ -278,10 +289,9 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
         first = self.client.get(f"/recitations/{self.asset.id}/")
         self.assertEqual(200, first.status_code, first.content)
 
-        # Second request: both caches are hot - repo must not be called.
+        # Second request: response + meta caches are hot - repo must not be called.
         with patch("apps.content.api.public.recitation_track_list.RecitationRepository") as mock_repo_cls:
             second = self.client.get(f"/recitations/{self.asset.id}/")
 
         self.assertEqual(200, second.status_code, second.content)
-        # Full cache hit must skip repo construction entirely, not just skip the DB call.
         mock_repo_cls.assert_not_called()


### PR DESCRIPTION
Cache full paginated JSON bytes per (asset_id, page, page_size). Cache hit returns HttpResponse directly with zero Pydantic/JSON/gzip work. Removes @paginate dependency; pagination manual with cap. Adds Cache-Control: public, max-age=300, s-maxage=300 on 200 responses for Cloudflare edge cache.