### PR TITLE
perf: batch Mixpanel tracking via Redis buffer

### DIFF
--- a/apps/content/tests/public/test_usage_tracking_integration.py
+++ b/apps/content/tests/public/test_usage_tracking_integration.py
@@ -1,7 +1,8 @@
 """End-to-end checks that the @track_usage decorator records the *served* asset's
 publisher (not the requester's), across the four tracked public endpoints."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 from model_bakery import baker
@@ -17,7 +18,7 @@ from apps.usage_tracking.decorators.track_usage import (
 )
 from apps.users.models import User
 
-_TASK = "apps.usage_tracking.decorators.track_usage.track_api_request_task"
+_REDIS = "apps.usage_tracking.decorators.track_usage._get_tracking_redis"
 
 
 class UsageTrackingIntegrationTest(BaseTestCase):
@@ -57,71 +58,73 @@ class UsageTrackingIntegrationTest(BaseTestCase):
         )
         self.authenticate_client(self.app)
 
-    def _props(self, mock_task):
-        assert mock_task.delay.called
-        return mock_task.delay.call_args.kwargs["properties"]
+    def _props(self, mock_get_redis):
+        mock_r = mock_get_redis.return_value
+        assert mock_r.rpush.called, "expected rpush to be called on Redis mock"
+        raw = mock_r.rpush.call_args[0][1]
+        return json.loads(raw)["properties"]
 
-    @patch(_TASK)
-    def test_recitations_list_records_distinct_publishers_of_served_assets(self, mock_task):
+    @patch(_REDIS)
+    def test_recitations_list_records_distinct_publishers_of_served_assets(self, mock_get_redis):
         response = self.client.get("/recitations/")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual("recitation", props["entity_type"])
         self.assertCountEqual([self.asset_a.id, self.asset_b.id], props["entity_ids"])
         # Both publishers present -- derived per served asset, not from the requester.
         self.assertCountEqual([self.publisher_a.id, self.publisher_b.id], props["publisher_ids"])
 
-    @patch(_TASK)
-    def test_recitation_detail_records_only_that_assets_publisher(self, mock_task):
+    @patch(_REDIS)
+    def test_recitation_detail_records_only_that_assets_publisher(self, mock_get_redis):
         response = self.client.get(f"/recitations/{self.asset_b.id}/")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual("recitation", props["entity_type"])
         self.assertEqual([self.asset_b.id], props["entity_ids"])
         self.assertEqual(self.asset_b.name, props["accessed_entity_name"])
         # Served asset belongs to publisher_b, NOT the requester's publisher_a.
         self.assertEqual([self.publisher_b.id], props["publisher_ids"])
 
-    @patch(_TASK)
-    def test_recitation_detail_404_dispatches_nothing(self, mock_task):
+    @patch(_REDIS)
+    def test_recitation_detail_404_dispatches_nothing(self, mock_get_redis):
         response = self.client.get("/recitations/999999/")
         self.assertEqual(404, response.status_code, response.content)
-        mock_task.delay.assert_not_called()
+        mock_get_redis.return_value.rpush.assert_not_called()
 
-    @patch(_TASK)
-    def test_reciters_list_records_entities_with_no_publisher(self, mock_task):
+    @patch(_REDIS)
+    def test_reciters_list_records_entities_with_no_publisher(self, mock_get_redis):
         response = self.client.get("/reciters/")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual("reciter", props["entity_type"])
         self.assertIn(self.reciter.id, props["entity_ids"])
         self.assertEqual([], props["publisher_ids"])
 
-    @patch(_TASK)
-    def test_riwayahs_list_records_entities_with_no_publisher(self, mock_task):
+    @patch(_REDIS)
+    def test_riwayahs_list_records_entities_with_no_publisher(self, mock_get_redis):
         response = self.client.get("/riwayahs/")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual("riwayah", props["entity_type"])
         self.assertIn(self.riwayah.id, props["entity_ids"])
         self.assertEqual([], props["publisher_ids"])
 
-    @patch(_TASK)
-    def test_reciter_id_filter_records_reciter_name(self, mock_task):
+    @patch(_REDIS)
+    def test_reciter_id_filter_records_reciter_name(self, mock_get_redis):
         response = self.client.get(f"/recitations/?reciter_id={self.reciter.id}")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual(self.reciter.id, props["filter_reciter_id"])
         self.assertEqual(self.reciter.name, props["filter_reciter_name"])
         self.assertEqual([self.reciter.name], props["filter_reciter_names"])
 
-    @patch(_TASK)
-    def test_multiple_reciter_id_filters_record_all_names(self, mock_task):
+    @patch(_REDIS)
+    def test_multiple_reciter_id_filters_record_all_names(self, mock_get_redis):
         other_reciter = baker.make("content.Reciter", name="Reciter W", is_active=True)
         baker.make(
             Asset,
@@ -135,12 +138,12 @@ class UsageTrackingIntegrationTest(BaseTestCase):
         response = self.client.get(f"/recitations/?reciter_id={self.reciter.id}&reciter_id={other_reciter.id}")
         self.assertEqual(200, response.status_code, response.content)
 
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual([self.reciter.name, other_reciter.name], props["filter_reciter_names"])
         self.assertEqual(self.reciter.name, props["filter_reciter_name"])
 
-    @patch(_TASK)
-    def test_recitations_list_where_qiraah_riwayah_reciter_filters_should_be_sent_to_mixpanel(self, mock_task):
+    @patch(_REDIS)
+    def test_recitations_list_where_qiraah_riwayah_reciter_filters_should_be_sent_to_mixpanel(self, mock_get_redis):
         # Arrange
         qiraah = baker.make("content.Qiraah", name="Qiraah Q", is_active=True)
 
@@ -151,7 +154,7 @@ class UsageTrackingIntegrationTest(BaseTestCase):
 
         # Assert
         self.assertEqual(200, response.status_code, response.content)
-        props = self._props(mock_task)
+        props = self._props(mock_get_redis)
         self.assertEqual(qiraah.id, props["filter_qiraah_id"])
         self.assertEqual(self.riwayah.id, props["filter_riwayah_id"])
         self.assertEqual(self.reciter.id, props["filter_reciter_id"])

--- a/apps/content/tests/public/test_usage_tracking_integration.py
+++ b/apps/content/tests/public/test_usage_tracking_integration.py
@@ -2,7 +2,7 @@
 publisher (not the requester's), across the four tracked public endpoints."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.core.cache import cache
 from model_bakery import baker

--- a/apps/usage_tracking/decorators/track_usage.py
+++ b/apps/usage_tracking/decorators/track_usage.py
@@ -22,9 +22,11 @@ from typing import Any
 from urllib.parse import parse_qs
 import uuid
 
+import json
+
 from django.core.cache import cache
 
-from apps.usage_tracking.tasks import track_api_request_task
+from apps.usage_tracking.tasks import TRACKING_BUFFER_KEY, _get_tracking_redis
 
 logger = logging.getLogger(__name__)
 
@@ -225,12 +227,18 @@ def _dispatch(
         # Mixpanel resolves geo from $ip on ingest and does not store the raw IP.
         properties["$ip"] = ip
 
-    track_api_request_task.delay(
-        distinct_id=_distinct_id(request),
-        event=event,
-        properties=properties,
-        meta={},
+    payload = json.dumps(
+        {
+            "distinct_id": _distinct_id(request),
+            "event": event,
+            "properties": properties,
+            "meta": {},
+        }
     )
+    try:
+        _get_tracking_redis().rpush(TRACKING_BUFFER_KEY, payload)
+    except Exception:
+        logger.exception("usage_tracking: failed to push event to Redis buffer")
 
 
 def _parsed_reciter_ids(query_string: str) -> list[int]:

--- a/apps/usage_tracking/decorators/track_usage.py
+++ b/apps/usage_tracking/decorators/track_usage.py
@@ -16,13 +16,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
+import json
 import logging
 import time
 from typing import Any
 from urllib.parse import parse_qs
 import uuid
-
-import json
 
 from django.core.cache import cache
 

--- a/apps/usage_tracking/services/mixpanel_client.py
+++ b/apps/usage_tracking/services/mixpanel_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mixpanel import Consumer, Mixpanel
+from mixpanel import BufferedConsumer, Consumer, Mixpanel
 
 
 class MixpanelIngestClient:
@@ -20,3 +20,22 @@ class MixpanelIngestClient:
         if self._sdk is None:
             self._sdk = Mixpanel(self._token, consumer=Consumer(api_host=self._ingest_host))
         self._sdk.track(distinct_id, event, properties, meta=meta)
+
+    def track_batch(self, events: list[dict[str, Any]]) -> None:
+        """Send a batch of pre-serialized events in a single HTTP call.
+
+        Each event dict must have keys: distinct_id, event, properties, meta.
+        No-ops when disabled, empty list, or no token.
+        """
+        if not self._enabled or not self._token or not events:
+            return
+        consumer = BufferedConsumer(max_size=len(events), api_host=self._ingest_host)
+        sdk = Mixpanel(self._token, consumer=consumer)
+        for item in events:
+            sdk.track(
+                item["distinct_id"],
+                item["event"],
+                item.get("properties", {}),
+                meta=item.get("meta"),
+            )
+        consumer.flush()

--- a/apps/usage_tracking/tasks.py
+++ b/apps/usage_tracking/tasks.py
@@ -5,16 +5,26 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 import functools
+import json
+import logging
 from typing import Any
 
 from celery import shared_task
 from django.conf import settings
 from django.db import connections
+import redis
 from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout as RequestsTimeout
 
 from apps.usage_tracking.services.mixpanel_client import MixpanelIngestClient
 
+logger = logging.getLogger(__name__)
+
 _TRANSIENT_ERRORS = (RequestsConnectionError, RequestsTimeout, ConnectionError, TimeoutError)
+
+TRACKING_BUFFER_KEY = "usage_tracking:tracking_buffer"
+_TRACKING_INFLIGHT_KEY = "usage_tracking:tracking_buffer:inflight"
+# Separate Redis DB from the Django cache (DB 1) to avoid eviction by cache policies.
+_TRACKING_REDIS_DB = 2
 
 
 class UnexpectedDatabaseQuery(AssertionError):
@@ -58,6 +68,27 @@ def _build_ingest_client() -> MixpanelIngestClient:
     )
 
 
+_tracking_redis_client: redis.Redis | None = None
+
+
+def _get_tracking_redis() -> redis.Redis:
+    """Return the module-level Redis client for the tracking buffer (DB 2).
+
+    Uses the same host/port as the Django cache (REDIS_URL) but a separate DB so
+    an allkeys-lru eviction policy on the cache DB cannot drop buffered events.
+    Lazy-initialised so Django settings are available at first call.
+    """
+    global _tracking_redis_client
+    if _tracking_redis_client is None:
+        base_url: str = getattr(settings, "REDIS_URL", "redis://localhost:6379/1")
+        url_without_db = base_url.rsplit("/", 1)[0]
+        tracking_url = f"{url_without_db}/{_TRACKING_REDIS_DB}"
+        _tracking_redis_client = redis.Redis.from_url(
+            tracking_url, socket_connect_timeout=1, socket_timeout=1, decode_responses=True
+        )
+    return _tracking_redis_client
+
+
 @shared_task(
     bind=True,
     autoretry_for=_TRANSIENT_ERRORS,
@@ -83,3 +114,44 @@ def track_api_request_task(
     # the entity is already loaded) so this task never needs to touch the database.
     client = _build_ingest_client()
     client.track(distinct_id, event, properties, meta=meta)
+
+
+@shared_task(ignore_result=True)
+@no_db_queries_task
+def flush_tracking_buffer_task() -> None:
+    """Drain the Redis tracking buffer and send all queued events to Mixpanel in one batch.
+
+    Uses RENAME to atomically move the live buffer to an inflight key before reading,
+    so concurrent requests keep writing to a fresh buffer and a crash between read and
+    delete cannot cause double-processing of the same batch on the next flush.
+    """
+    r = _get_tracking_redis()
+
+    # Atomically claim the current buffer. If the key doesn't exist, RENAME raises
+    # ResponseError -- treat that as empty buffer.
+    try:
+        r.rename(TRACKING_BUFFER_KEY, _TRACKING_INFLIGHT_KEY)
+    except redis.ResponseError:
+        return  # buffer was empty
+
+    try:
+        raw_items: list[str] = r.lrange(_TRACKING_INFLIGHT_KEY, 0, -1)
+    finally:
+        r.delete(_TRACKING_INFLIGHT_KEY)
+
+    if not raw_items:
+        return
+
+    events: list[dict[str, Any]] = []
+    for raw in raw_items:
+        try:
+            events.append(json.loads(raw))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("flush_tracking_buffer_task: skipping malformed event: %.120s", raw)
+
+    if not events:
+        return
+
+    client = _build_ingest_client()
+    client.track_batch(events)
+    logger.info("flush_tracking_buffer_task: sent %d events to Mixpanel", len(events))

--- a/apps/usage_tracking/tasks.py
+++ b/apps/usage_tracking/tasks.py
@@ -74,14 +74,14 @@ _tracking_redis_client: redis.Redis | None = None
 def _get_tracking_redis() -> redis.Redis:
     """Return the module-level Redis client for the tracking buffer (DB 2).
 
-    Uses the same host/port as the Django cache (REDIS_URL) but a separate DB so
-    an allkeys-lru eviction policy on the cache DB cannot drop buffered events.
-    Lazy-initialised so Django settings are available at first call.
+    Derives host/port from CACHES["default"]["LOCATION"] (the authoritative cache URL)
+    and swaps the DB to the dedicated tracking DB so cache eviction policies cannot
+    drop buffered events. Lazy-initialised so Django settings are available at first call.
     """
     global _tracking_redis_client
     if _tracking_redis_client is None:
-        base_url: str = getattr(settings, "REDIS_URL", "redis://localhost:6379/1")
-        url_without_db = base_url.rsplit("/", 1)[0]
+        cache_url: str = settings.CACHES["default"]["LOCATION"]
+        url_without_db = cache_url.rsplit("/", 1)[0]
         tracking_url = f"{url_without_db}/{_TRACKING_REDIS_DB}"
         _tracking_redis_client = redis.Redis.from_url(
             tracking_url, socket_connect_timeout=1, socket_timeout=1, decode_responses=True
@@ -134,12 +134,10 @@ def flush_tracking_buffer_task() -> None:
     except redis.ResponseError:
         return  # buffer was empty
 
-    try:
-        raw_items: list[str] = r.lrange(_TRACKING_INFLIGHT_KEY, 0, -1)
-    finally:
-        r.delete(_TRACKING_INFLIGHT_KEY)
+    raw_items: list[str] = r.lrange(_TRACKING_INFLIGHT_KEY, 0, -1)
 
     if not raw_items:
+        r.delete(_TRACKING_INFLIGHT_KEY)
         return
 
     events: list[dict[str, Any]] = []
@@ -149,9 +147,13 @@ def flush_tracking_buffer_task() -> None:
         except (json.JSONDecodeError, TypeError):
             logger.warning("flush_tracking_buffer_task: skipping malformed event: %.120s", raw)
 
-    if not events:
-        return
-
-    client = _build_ingest_client()
-    client.track_batch(events)
-    logger.info("flush_tracking_buffer_task: sent %d events to Mixpanel", len(events))
+    # Send then delete in finally so inflight is always cleaned up. A network failure
+    # during track_batch logs and drops the batch -- analytics loss is acceptable and
+    # leaving inflight would not help (next RENAME silently overwrites it anyway).
+    try:
+        if events:
+            client = _build_ingest_client()
+            client.track_batch(events)
+            logger.info("flush_tracking_buffer_task: sent %d events to Mixpanel", len(events))
+    finally:
+        r.delete(_TRACKING_INFLIGHT_KEY)

--- a/apps/usage_tracking/tests/test_tasks.py
+++ b/apps/usage_tracking/tests/test_tasks.py
@@ -5,9 +5,9 @@ import pytest
 import redis
 
 from apps.usage_tracking.tasks import (
+    _TRACKING_INFLIGHT_KEY,
     TRACKING_BUFFER_KEY,
     UnexpectedDatabaseQuery,
-    _TRACKING_INFLIGHT_KEY,
     flush_tracking_buffer_task,
     no_db_queries,
     track_api_request_task,

--- a/apps/usage_tracking/tests/test_tasks.py
+++ b/apps/usage_tracking/tests/test_tasks.py
@@ -187,18 +187,23 @@ class TestFlushTrackingBufferTask:
 
     @patch("apps.usage_tracking.tasks._build_ingest_client")
     @patch("apps.usage_tracking.tasks._get_tracking_redis")
-    def test_flush_tracking_buffer_task_where_lrange_raises_should_still_delete_inflight(
+    def test_flush_tracking_buffer_task_where_track_batch_raises_should_still_delete_inflight(
         self, mock_get_redis, mock_build
     ):
-        """Inflight key is deleted in a finally block so it doesn't linger on crash."""
-        mock_r = MagicMock()
-        mock_r.rename.return_value = True
-        mock_r.lrange.side_effect = redis.ResponseError("ERR crash")
+        """Inflight key is always deleted after the send attempt.
+
+        A network failure drops the batch (analytics loss is acceptable) but must
+        not leave the inflight key lingering -- next RENAME would silently overwrite
+        it, losing both old and new data.
+        """
+        events = [_make_event("user-1")]
+        mock_r = self._mock_redis_with_events(events)
         mock_get_redis.return_value = mock_r
         client = MagicMock()
+        client.track_batch.side_effect = ConnectionError("Mixpanel down")
         mock_build.return_value = client
 
-        with pytest.raises(redis.ResponseError):
+        with pytest.raises(ConnectionError):
             flush_tracking_buffer_task.run()
 
         mock_r.delete.assert_called_once_with(_TRACKING_INFLIGHT_KEY)

--- a/apps/usage_tracking/tests/test_tasks.py
+++ b/apps/usage_tracking/tests/test_tasks.py
@@ -1,8 +1,17 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import redis
 
-from apps.usage_tracking.tasks import UnexpectedDatabaseQuery, no_db_queries, track_api_request_task
+from apps.usage_tracking.tasks import (
+    TRACKING_BUFFER_KEY,
+    UnexpectedDatabaseQuery,
+    _TRACKING_INFLIGHT_KEY,
+    flush_tracking_buffer_task,
+    no_db_queries,
+    track_api_request_task,
+)
 
 
 class TestTrackApiRequestTask:
@@ -107,3 +116,105 @@ class TestNoDbQueries:
 
         with pytest.raises(UnexpectedDatabaseQuery), no_db_queries():
             Asset.objects.filter(pk=1).exists()
+
+
+def _make_event(distinct_id="user-1", event="public_api_request", props=None):
+    return {
+        "distinct_id": distinct_id,
+        "event": event,
+        "properties": props or {"endpoint": "GET /recitations/"},
+        "meta": {},
+    }
+
+
+class TestFlushTrackingBufferTask:
+    def _mock_redis_with_events(self, events):
+        """Return a mock Redis client that simulates a buffer containing the given events."""
+        mock_r = MagicMock()
+        mock_r.rename.return_value = True
+        mock_r.lrange.return_value = [json.dumps(e) for e in events]
+        return mock_r
+
+    @patch("apps.usage_tracking.tasks._build_ingest_client")
+    @patch("apps.usage_tracking.tasks._get_tracking_redis")
+    def test_flush_tracking_buffer_task_where_buffer_has_events_should_send_batch(self, mock_get_redis, mock_build):
+        events = [_make_event("user-1"), _make_event("user-2")]
+        mock_r = self._mock_redis_with_events(events)
+        mock_get_redis.return_value = mock_r
+        client = MagicMock()
+        mock_build.return_value = client
+
+        flush_tracking_buffer_task.run()
+
+        mock_r.rename.assert_called_once_with(TRACKING_BUFFER_KEY, _TRACKING_INFLIGHT_KEY)
+        mock_r.lrange.assert_called_once_with(_TRACKING_INFLIGHT_KEY, 0, -1)
+        mock_r.delete.assert_called_once_with(_TRACKING_INFLIGHT_KEY)
+        client.track_batch.assert_called_once()
+        sent = client.track_batch.call_args[0][0]
+        assert len(sent) == 2
+        assert sent[0]["distinct_id"] == "user-1"
+        assert sent[1]["distinct_id"] == "user-2"
+
+    @patch("apps.usage_tracking.tasks._build_ingest_client")
+    @patch("apps.usage_tracking.tasks._get_tracking_redis")
+    def test_flush_tracking_buffer_task_where_buffer_empty_should_be_noop(self, mock_get_redis, mock_build):
+        mock_r = MagicMock()
+        mock_r.rename.side_effect = redis.ResponseError("ERR no such key")
+        mock_get_redis.return_value = mock_r
+        client = MagicMock()
+        mock_build.return_value = client
+
+        flush_tracking_buffer_task.run()
+
+        mock_r.lrange.assert_not_called()
+        client.track_batch.assert_not_called()
+
+    @patch("apps.usage_tracking.tasks._build_ingest_client")
+    @patch("apps.usage_tracking.tasks._get_tracking_redis")
+    def test_flush_tracking_buffer_task_where_inflight_is_empty_after_rename_should_be_noop(
+        self, mock_get_redis, mock_build
+    ):
+        mock_r = MagicMock()
+        mock_r.rename.return_value = True
+        mock_r.lrange.return_value = []
+        mock_get_redis.return_value = mock_r
+        client = MagicMock()
+        mock_build.return_value = client
+
+        flush_tracking_buffer_task.run()
+
+        client.track_batch.assert_not_called()
+
+    @patch("apps.usage_tracking.tasks._build_ingest_client")
+    @patch("apps.usage_tracking.tasks._get_tracking_redis")
+    def test_flush_tracking_buffer_task_where_lrange_raises_should_still_delete_inflight(
+        self, mock_get_redis, mock_build
+    ):
+        """Inflight key is deleted in a finally block so it doesn't linger on crash."""
+        mock_r = MagicMock()
+        mock_r.rename.return_value = True
+        mock_r.lrange.side_effect = redis.ResponseError("ERR crash")
+        mock_get_redis.return_value = mock_r
+        client = MagicMock()
+        mock_build.return_value = client
+
+        with pytest.raises(redis.ResponseError):
+            flush_tracking_buffer_task.run()
+
+        mock_r.delete.assert_called_once_with(_TRACKING_INFLIGHT_KEY)
+
+    @patch("apps.usage_tracking.tasks._build_ingest_client")
+    @patch("apps.usage_tracking.tasks._get_tracking_redis")
+    def test_flush_tracking_buffer_task_where_event_is_malformed_json_should_skip_it(self, mock_get_redis, mock_build):
+        mock_r = MagicMock()
+        mock_r.rename.return_value = True
+        mock_r.lrange.return_value = ["not-json", json.dumps(_make_event("user-good"))]
+        mock_get_redis.return_value = mock_r
+        client = MagicMock()
+        mock_build.return_value = client
+
+        flush_tracking_buffer_task.run()
+
+        sent = client.track_batch.call_args[0][0]
+        assert len(sent) == 1
+        assert sent[0]["distinct_id"] == "user-good"

--- a/apps/usage_tracking/tests/test_track_usage.py
+++ b/apps/usage_tracking/tests/test_track_usage.py
@@ -1,5 +1,6 @@
+import json
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
@@ -13,6 +14,7 @@ from apps.usage_tracking.decorators.track_usage import (
     track_extra,
     track_usage,
 )
+from apps.usage_tracking.tasks import TRACKING_BUFFER_KEY
 
 
 def _obj(id_, name, publisher_id=None, publisher_name=None):
@@ -20,12 +22,29 @@ def _obj(id_, name, publisher_id=None, publisher_name=None):
     return SimpleNamespace(id=id_, name=name, publisher_id=publisher_id, publisher=publisher)
 
 
+def _mock_redis():
+    """Return a mock Redis client and a helper to inspect what was pushed."""
+    mock_r = MagicMock()
+    mock_get_redis = MagicMock(return_value=mock_r)
+    return mock_get_redis, mock_r
+
+
+def _dispatched_props(mock_r):
+    """Parse the JSON payload pushed to the tracking buffer and return its properties."""
+    assert mock_r.rpush.called, "expected rpush to be called on Redis mock"
+    raw = mock_r.rpush.call_args[0][1]
+    return json.loads(raw)["properties"]
+
+
 class TestTrackUsageDecorator:
     def setup_method(self):
         self.factory = RequestFactory()
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_paginated_list_extracts_entities_and_publishers(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_paginated_list_extracts_entities_and_publishers(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage(entity_type="recitation", publisher_from="publisher")
         def view(request):
             return {
@@ -39,36 +58,40 @@ class TestTrackUsageDecorator:
 
         view(self.factory.get("/recitations/"))
 
-        assert mock_task.delay.called
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["entity_type"] == "recitation"
         assert props["entity_ids"] == [1, 2, 3]
         assert props["entity_names"] == ["A", "B", "C"]
-        # distinct, preserving first-seen order
         assert props["publisher_ids"] == [10, 20]
         assert props["publisher_names"] == ["Pub10", "Pub20"]
         assert props["status_code"] == 200
         assert "latency_ms" in props
+        mock_r.rpush.assert_called_once_with(TRACKING_BUFFER_KEY, mock_r.rpush.call_args[0][1])
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_no_publisher_from_leaves_publishers_empty(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_no_publisher_from_leaves_publishers_empty(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage(entity_type="reciter")
         def view(request):
             return {"results": [_obj(1, "Reciter")], "count": 1}
 
         view(self.factory.get("/reciters/"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["entity_type"] == "reciter"
         assert props["entity_ids"] == [1]
         assert props["publisher_ids"] == []
         assert props["publisher_names"] == []
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_track_extra_overrides_auto_extracted(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_track_extra_overrides_auto_extracted(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage(entity_type="recitation", publisher_from="publisher")
         def view(request):
-            # The detail endpoint serves track rows but wants to record the Asset.
             track_extra(
                 request,
                 entity_ids=[99],
@@ -81,14 +104,17 @@ class TestTrackUsageDecorator:
 
         view(self.factory.get("/recitations/99/"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["entity_ids"] == [99]
         assert props["entity_names"] == ["Asset 99"]
         assert props["accessed_entity_name"] == "Asset 99"
         assert props["publisher_ids"] == [7]
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_track_extra_merges_across_calls(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_track_extra_merges_across_calls(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage()
         def view(request):
             track_extra(request, a=1)
@@ -97,12 +123,15 @@ class TestTrackUsageDecorator:
 
         view(self.factory.get("/recitations/"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["a"] == 1
         assert props["b"] == 2
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_raising_view_does_not_dispatch(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_raising_view_does_not_dispatch(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage(entity_type="recitation")
         def view(request):
             raise ValueError("boom")
@@ -112,11 +141,13 @@ class TestTrackUsageDecorator:
         except ValueError:
             pass
 
-        mock_task.delay.assert_not_called()
+        mock_r.rpush.assert_not_called()
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_dispatch_failure_does_not_break_response(self, mock_task):
-        mock_task.delay.side_effect = RuntimeError("broker down")
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_dispatch_failure_does_not_break_response(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_r.rpush.side_effect = RuntimeError("redis down")
+        mock_get_redis.return_value = mock_r
 
         @track_usage()
         def view(request):
@@ -126,32 +157,36 @@ class TestTrackUsageDecorator:
 
         assert result == {"results": [], "count": 0}
 
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_query_params_captured(self, mock_task):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_query_params_captured(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage()
         def view(request):
             return {"results": [], "count": 0}
 
-        # riwayah_id (not reciter_id) avoids the reciter-name DB lookup; that path has
-        # its own tests below.
         view(self.factory.get("/recitations/?page=2&search=hafs&riwayah_id=2&ordering=name"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["page"] == 2
         assert props["search"] == "hafs"
         assert props["filter_riwayah_id"] == 2
         assert props["ordering"] == "name"
 
     @patch("apps.usage_tracking.decorators.track_usage._resolve_reciter_names", return_value=["Mishary"])
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_reciter_filter_adds_human_readable_name(self, mock_task, mock_resolve):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_reciter_filter_adds_human_readable_name(self, mock_get_redis, mock_resolve):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage()
         def view(request):
             return {"results": [], "count": 0}
 
         view(self.factory.get("/recitations/?reciter_id=6"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["filter_reciter_id"] == 6
         assert props["filter_reciter_name"] == "Mishary"
         assert props["filter_reciter_names"] == ["Mishary"]
@@ -161,33 +196,71 @@ class TestTrackUsageDecorator:
         "apps.usage_tracking.decorators.track_usage._resolve_reciter_names",
         return_value=["Mishary", "Saad"],
     )
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_multiple_reciter_filters_resolve_all_names(self, mock_task, mock_resolve):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_multiple_reciter_filters_resolve_all_names(self, mock_get_redis, mock_resolve):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage()
         def view(request):
             return {"results": [], "count": 0}
 
         view(self.factory.get("/recitations/?reciter_id=6&reciter_id=9"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert props["filter_reciter_names"] == ["Mishary", "Saad"]
-        # filter_reciter_name keeps the first id for back-compat.
         assert props["filter_reciter_name"] == "Mishary"
         mock_resolve.assert_called_once_with([6, 9])
 
     @patch("apps.usage_tracking.decorators.track_usage._resolve_reciter_names")
-    @patch("apps.usage_tracking.decorators.track_usage.track_api_request_task")
-    def test_no_reciter_filter_skips_name_resolution(self, mock_task, mock_resolve):
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_no_reciter_filter_skips_name_resolution(self, mock_get_redis, mock_resolve):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
         @track_usage()
         def view(request):
             return {"results": [], "count": 0}
 
         view(self.factory.get("/recitations/"))
 
-        props = mock_task.delay.call_args.kwargs["properties"]
+        props = _dispatched_props(mock_r)
         assert "filter_reciter_name" not in props
         assert "filter_reciter_names" not in props
         mock_resolve.assert_not_called()
+
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_dispatch_pushes_to_correct_buffer_key(self, mock_get_redis):
+        """Event must land on TRACKING_BUFFER_KEY so flush task finds it."""
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
+        @track_usage()
+        def view(request):
+            return {"results": [], "count": 0}
+
+        view(self.factory.get("/recitations/"))
+
+        assert mock_r.rpush.call_args[0][0] == TRACKING_BUFFER_KEY
+
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_dispatch_payload_is_valid_json_with_required_keys(self, mock_get_redis):
+        """Flush task expects distinct_id, event, properties, meta keys."""
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
+        @track_usage()
+        def view(request):
+            return {"results": [], "count": 0}
+
+        view(self.factory.get("/recitations/"))
+
+        raw = mock_r.rpush.call_args[0][1]
+        payload = json.loads(raw)
+        assert "distinct_id" in payload
+        assert "event" in payload
+        assert "properties" in payload
+        assert "meta" in payload
 
 
 class TestDistinctId:

--- a/apps/usage_tracking/tests/test_track_usage.py
+++ b/apps/usage_tracking/tests/test_track_usage.py
@@ -1,6 +1,6 @@
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory

--- a/config/celery.py
+++ b/config/celery.py
@@ -2,8 +2,8 @@
 Celery configuration for Itqan CMS
 """
 
-import os
 from datetime import timedelta
+import os
 
 from celery import Celery
 from celery.schedules import crontab

--- a/config/celery.py
+++ b/config/celery.py
@@ -3,6 +3,7 @@ Celery configuration for Itqan CMS
 """
 
 import os
+from datetime import timedelta
 
 from celery import Celery
 from celery.schedules import crontab
@@ -28,6 +29,10 @@ app.conf.beat_schedule = {
     "expire-publisher-member-invitations": {
         "task": "apps.publishers.tasks.expire_publisher_member_invitations",
         "schedule": crontab(minute=0, hour=0),
+    },
+    "flush-tracking-buffer": {
+        "task": "apps.usage_tracking.tasks.flush_tracking_buffer_task",
+        "schedule": timedelta(seconds=30),
     },
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: each API request queued one track_api_request_task via RabbitMQ; at traffic spike ~80k messages backlogged, driving beam.smp to 81% CPU on the 2-vCPU droplet
- **Fix**: replace per-request .delay() with RPUSH onto a Redis list (DB 2, isolated from cache DB to prevent LRU eviction); a beat task flush_tracking_buffer_task (every 30s) atomically drains the buffer and sends all events to Mixpanel in one batched HTTP call via BufferedConsumer
- **Result**: RabbitMQ messages drop from 1-per-request to 2/min; track_api_request_task kept intact to drain existing backlog

## Files changed

| File | Change |
|---|---|
| apps/usage_tracking/decorators/track_usage.py | _dispatch() now RPUSH to Redis buffer instead of .delay() |
| apps/usage_tracking/tasks.py | Add flush_tracking_buffer_task, _get_tracking_redis() helper, buffer key constants |
| apps/usage_tracking/services/mixpanel_client.py | Add track_batch() using BufferedConsumer (one HTTP call per flush) |
| config/celery.py | Add flush-tracking-buffer beat entry with 30s timedelta schedule |
| apps/usage_tracking/tests/test_tasks.py | Tests for flush_tracking_buffer_task |
| apps/usage_tracking/tests/test_track_usage.py | Updated all dispatch tests to assert Redis RPUSH |

## Operational note

CELERY_WORKER_CONCURRENCY=6 was added to prod .env and worker restarted to drain existing backlog while this PR is reviewed.

## Test plan

- [ ] CI green (pytest in Docker)
- [ ] After deploy: verify rabbitmqctl list_queues message count does not grow
- [ ] Check celery-beat logs every 30s shows flush_tracking_buffer_task executing
- [ ] Verify Mixpanel event volume unchanged (buffered then flushed, not dropped)