### PR TITLE
Feature/control asset access from public APIs

### DIFF
--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -6,6 +6,7 @@ from ninja import Schema
 from ninja.pagination import paginate
 
 from apps.content.repositories.recitation import RecitationRepository
+from apps.content.services.asset_access import enforce_asset_access
 from apps.content.services.recitation import RecitationService
 from apps.core.mixins.constants import QURAN_SURAHS
 from apps.core.ninja_utils.errors import NinjaErrorResponse
@@ -40,7 +41,12 @@ class RecitationSurahTrackOut(Schema):
 
 @router.get(
     "recitations/{asset_id}/",
-    response={200: list[RecitationSurahTrackOut], 404: NinjaErrorResponse[Literal["not_found"]]},
+    response={
+        200: list[RecitationSurahTrackOut],
+        401: NinjaErrorResponse[Literal["authentication_required"]],
+        403: NinjaErrorResponse[Literal["access_denied"]],
+        404: NinjaErrorResponse[Literal["not_found"]],
+    },
 )
 @track_usage()
 @paginate
@@ -52,6 +58,8 @@ def list_recitation_tracks(request: Request, asset_id: int):
     asset = repo.get_asset_object(asset_id, Q(restricted_for_tenant=False))
     if not asset:
         raise Http404("No asset matches the given query.")
+
+    enforce_asset_access(getattr(request, "user", None), asset)
 
     # Publisher is a property of the served Asset (select_related in get_asset_object).
     track_extra(

--- a/apps/content/services/asset_access.py
+++ b/apps/content/services/asset_access.py
@@ -166,6 +166,33 @@ def guard_restrict_for_tenant(asset: Asset) -> None:
     )
 
 
+def enforce_asset_access(user: User | None, asset: Asset) -> None:
+    """Gate consumption of an asset's content behind an API key + approved access.
+
+    Open-access assets are free to consume by anyone. For assets the publisher keeps
+    behind the access-request cycle, the consumer must (1) be authenticated — i.e. pass
+    a valid API key — and (2) hold an active access grant (an approved access request).
+    A missing/invalid key yields 401; an authenticated consumer without an approved
+    grant (not requested, pending, or rejected) yields 403.
+    """
+    if asset.is_open_access:
+        return
+
+    if not (user and user.is_authenticated):
+        raise ItqanError(
+            "authentication_required",
+            _("An API key is required to access this asset's content."),
+            status_code=401,
+        )
+
+    if not user_has_access(user, asset):
+        raise ItqanError(
+            "access_denied",
+            _("You don't have an approved access request for this asset."),
+            status_code=403,
+        )
+
+
 def user_has_access(user: User, asset: Asset) -> bool:
     if asset.is_open_access:
         return True

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -2,10 +2,18 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 from oauth2_provider.models import Application
 
-from apps.content.models import Asset, CategoryChoice, RecitationAyahTiming, RecitationSurahTrack, StatusChoice
+from apps.content.models import (
+    Asset,
+    AssetAccess,
+    AssetAccessRequest,
+    CategoryChoice,
+    RecitationAyahTiming,
+    RecitationSurahTrack,
+    StatusChoice,
+)
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher
-from apps.users.models import User
+from apps.users.models import APIKey, User
 
 
 class RecitationTracksTest(BaseTestCase):
@@ -17,6 +25,7 @@ class RecitationTracksTest(BaseTestCase):
             category=CategoryChoice.RECITATION,
             publisher=self.publisher,
             status=StatusChoice.READY,
+            is_open_access=True,
             reciter=baker.make("content.Reciter", name="Test Reciter"),
             riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
         )
@@ -184,3 +193,100 @@ class RecitationTracksTest(BaseTestCase):
         items = body["results"]
         self.assertEqual(1, len(items))
         self.assertEqual([], items[0]["ayahs_timings"])
+
+
+class RecitationTracksAccessControlTest(BaseTestCase):
+    """Gating of the content endpoint behind API key + approved access request."""
+
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher)
+        self.asset = baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            publisher=self.publisher,
+            status=StatusChoice.READY,
+            is_open_access=False,
+            reciter=baker.make("content.Reciter", name="Test Reciter"),
+            riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+        )
+        baker.make(
+            RecitationSurahTrack,
+            asset=self.asset,
+            surah_number=1,
+            duration_ms=1000,
+            size_bytes=512,
+        )
+        self.user = User.objects.create_user(email="dev@example.com", name="Dev")
+
+    def _authenticate_with_api_key(self, user: User) -> None:
+        _, raw_key = APIKey.objects.create_key(name="test-key", user=user)
+        self.client.credentials(HTTP_X_API_KEY=raw_key)
+
+    def _grant_access(self, user: User, asset: Asset) -> AssetAccess:
+        req = baker.make(
+            AssetAccessRequest,
+            developer_user=user,
+            asset=asset,
+            status=AssetAccessRequest.StatusChoice.APPROVED,
+        )
+        return baker.make(AssetAccess, asset_access_request=req, user=user, asset=asset, expires_at=None)
+
+    def test_open_access_asset_is_consumable_without_api_key(self):
+        self.asset.is_open_access = True
+        self.asset.save(update_fields=["is_open_access"])
+
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(200, response.status_code, response.content)
+
+    def test_restricted_asset_without_api_key_returns_401(self):
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(401, response.status_code, response.content)
+        self.assertEqual("authentication_required", response.json()["error_name"])
+
+    def test_restricted_asset_with_api_key_but_no_access_request_returns_403(self):
+        self._authenticate_with_api_key(self.user)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(403, response.status_code, response.content)
+        self.assertEqual("access_denied", response.json()["error_name"])
+
+    def test_restricted_asset_with_rejected_access_request_returns_403(self):
+        baker.make(
+            AssetAccessRequest,
+            developer_user=self.user,
+            asset=self.asset,
+            status=AssetAccessRequest.StatusChoice.REJECTED,
+        )
+        self._authenticate_with_api_key(self.user)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(403, response.status_code, response.content)
+        self.assertEqual("access_denied", response.json()["error_name"])
+
+    def test_restricted_asset_with_pending_access_request_returns_403(self):
+        baker.make(
+            AssetAccessRequest,
+            developer_user=self.user,
+            asset=self.asset,
+            status=AssetAccessRequest.StatusChoice.PENDING,
+        )
+        self._authenticate_with_api_key(self.user)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(403, response.status_code, response.content)
+        self.assertEqual("access_denied", response.json()["error_name"])
+
+    def test_restricted_asset_with_approved_access_returns_200(self):
+        self._grant_access(self.user, self.asset)
+        self._authenticate_with_api_key(self.user)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual(1, len(response.json()["results"]))

--- a/apps/content/tests/public/test_usage_tracking_integration.py
+++ b/apps/content/tests/public/test_usage_tracking_integration.py
@@ -42,6 +42,7 @@ class UsageTrackingIntegrationTest(BaseTestCase):
             category=CategoryChoice.RECITATION,
             publisher=self.publisher_b,
             status=StatusChoice.READY,
+            is_open_access=True,
             reciter=self.reciter,
             riwayah=self.riwayah,
         )

--- a/apps/core/ninja_utils/auth.py
+++ b/apps/core/ninja_utils/auth.py
@@ -1,7 +1,7 @@
 from allauth.headless.contrib.ninja.security import XSessionTokenAuth
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from ninja_keys.auth import ApiKeyAuth
+from ninja_keys.auth import ApiKeyAuth as BaseApiKeyAuth
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework_simplejwt.authentication import JWTAuthentication, JWTStatelessUserAuthentication
 
@@ -48,6 +48,28 @@ if settings.ENABLE_ALLAUTH:
     internal_auth = [SessionToken()]
 else:
     internal_auth = [JWTAuth(), JWTAuthStateless()]
+
+
+class ApiKeyAuth(BaseApiKeyAuth):
+    """API key auth that binds the key's owner to ``request.user``.
+
+    The upstream ``ApiKeyAuth.authenticate`` only returns a boolean, so the
+    consumer identity is lost. Per-asset access checks (access requests) need the
+    actual user, so we resolve the key to its owner and set ``request.user``.
+    """
+
+    def authenticate(self, request, key):
+        if not key:
+            return None
+        model = self.model
+        try:
+            api_key = model.objects.get_from_key(key)
+        except model.DoesNotExist:
+            return None
+        if api_key.has_expired:
+            return None
+        request.user = api_key.user
+        return api_key.user
 
 
 class PublicAuth:

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -167,6 +167,12 @@ msgstr "سبب الرفض مطلوب."
 msgid "This asset has open or granted access requests from public consumers and cannot be restricted to your tenant. Please contact Itqan team."
 msgstr "يحتوي هذا الأصل على طلبات وصول مفتوحة أو ممنوحة من مستهلكين عموميين، ولا يمكن حصره على موقعك. يرجى التواصل مع فريق إتقان."
 
+msgid "An API key is required to access this asset's content."
+msgstr "مطلوب مفتاح API للوصول إلى محتوى هذا الأصل."
+
+msgid "You don't have an approved access request for this asset."
+msgstr "ليس لديك طلب وصول مُوافَق عليه لهذا الأصل."
+
 msgid "Description must be at least 10 characters long."
 msgstr "يجب أن يكون الوصف 10 أحرف على الأقل."
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access checks for recitation content so restricted tracks now require valid permission before they can be viewed.
  * API key sign-in now carries the authenticated user through the request for downstream access handling.

* **Bug Fixes**
  * Public recitation responses now clearly return the correct access-related outcomes: unauthenticated, forbidden, or not found.
  * Updated test coverage and fixtures to reflect open-access and restricted content behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->