### PR TITLE
fix: cache asset name_ar so recitation detail cache-hit path does not 500

### DIFF
--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -98,7 +98,7 @@ def list_recitation_tracks(
     # Publisher is a property of the served Asset (select_related in get_asset_object).
     publisher_name = asset.publisher.name if asset.publisher_id else None
     asset_meta = {
-        "name": asset.name,
+        "name_ar": asset.name_ar,
         "publisher_id": asset.publisher_id,
         "publisher_name": publisher_name,
     }

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -308,6 +308,21 @@ class RecitationTracksPageSizeCapTest(BaseTestCase):
         self.assertEqual(200, second.status_code, second.content)
         self.assertEqual(first.json(), second.json())
 
+    def test_list_recitation_tracks_where_meta_cache_warm_should_not_500_on_second_request(self):
+        # Regression: asset_meta cache write must supply every key the cache-hit
+        # read path looks up (name_ar), or the second request raises KeyError -> 500.
+        from django.core.cache import cache as django_cache
+
+        self.authenticate_client(self.app)
+        django_cache.clear()
+
+        first = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, first.status_code, first.content)
+
+        second = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, second.status_code, second.content)
+        self.assertEqual(first.json(), second.json())
+
     def test_list_recitation_tracks_where_both_caches_warm_should_make_no_db_query(self):
         # Fails on old code where get_asset_object always ran before the cache check.
         from unittest.mock import patch

--- a/apps/content/tests/public/test_usage_tracking_integration.py
+++ b/apps/content/tests/public/test_usage_tracking_integration.py
@@ -84,7 +84,7 @@ class UsageTrackingIntegrationTest(BaseTestCase):
         props = self._props(mock_get_redis)
         self.assertEqual("recitation", props["entity_type"])
         self.assertEqual([self.asset_b.id], props["entity_ids"])
-        self.assertEqual(self.asset_b.name, props["accessed_entity_name"])
+        self.assertEqual(self.asset_b.name_ar, props["accessed_entity_name"])
         # Served asset belongs to publisher_b, NOT the requester's publisher_a.
         self.assertEqual([self.publisher_b.id], props["publisher_ids"])
 

--- a/apps/usage_tracking/tests/test_track_usage.py
+++ b/apps/usage_tracking/tests/test_track_usage.py
@@ -18,8 +18,8 @@ from apps.usage_tracking.tasks import TRACKING_BUFFER_KEY
 
 
 def _obj(id_, name, publisher_id=None, publisher_name=None):
-    publisher = SimpleNamespace(id=publisher_id, name=publisher_name) if publisher_id else None
-    return SimpleNamespace(id=id_, name=name, publisher_id=publisher_id, publisher=publisher)
+    publisher = SimpleNamespace(id=publisher_id, name=publisher_name, name_ar=publisher_name) if publisher_id else None
+    return SimpleNamespace(id=id_, name=name, name_ar=name, publisher_id=publisher_id, publisher=publisher)
 
 
 def _mock_redis():


### PR DESCRIPTION
## Summary
- Fixes intermittent 500s on `GET /recitations/{id}/` on staging (e.g. `staging.api.cms.itqan.dev/recitations/2/`).
- Root cause: `86d8c611` changed the cache-hit read path in `list_recitation_tracks` to use `cached_meta["name_ar"]`, but the cache-write side (`asset_meta` dict) still only stored `"name"`. Every request served from the warm asset-meta cache (all but the first request each cache cycle) raised `KeyError: 'name_ar'` -> 500.
- Reproduced directly against staging (`curl` loop: 1x 200 then repeated 500s) and confirmed via `docker logs docker-web-1` traceback. Response cache TTL is 5 min, which matches the reported "works once, then fails for ~3-5 min" cycle.
- Fix: `asset_meta` now stores `name_ar` (dropped the now-unused `name` key) so cache write matches cache read.

## Test plan
- [x] Added `test_list_recitation_tracks_where_meta_cache_warm_should_not_500_on_second_request` — confirmed it fails with `KeyError: 'name_ar'` on the pre-fix code, passes after the fix.
- [x] Full `apps/content/tests/public/test_recitation_detail.py` suite passes (20/20) against a local Postgres.
- [ ] After merge/deploy to staging: repeat manual repro (`curl -o /dev/null -w "%{http_code}" https://staging.api.cms.itqan.dev/recitations/2/` x6 spanning >5 min) and confirm no 500s, tail `docker logs docker-web-1` for absence of the `KeyError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where repeated requests for recitation track listings could fail after cached metadata was used.
  * Ensured cached and uncached requests return consistent results.

* **Tests**
  * Added regression coverage for repeated recitation track list requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->