### PR TITLE
feat(reciters): public reciters API + reciter-attributed assets

### DIFF
--- a/apps/content/api/internal/assets_detail.py
+++ b/apps/content/api/internal/assets_detail.py
@@ -29,6 +29,11 @@ class DetailAssetPublisherOut(Schema):
     description: str
 
 
+class DetailAssetReciterOut(Schema):
+    id: int
+    name: str
+
+
 class DetailAssetOut(Schema):
     id: int
     category: str
@@ -37,6 +42,7 @@ class DetailAssetOut(Schema):
     long_description: str
     thumbnail_url: AbsoluteUrl | None
     publisher: DetailAssetPublisherOut = Field(alias="publisher")
+    reciter: DetailAssetReciterOut | None = None
     license: LicenseChoice
     is_open_access: bool
     snapshots: list[DetailAssetSnapshotOut] = Field(default_factory=list, alias="previews")

--- a/apps/content/api/internal/assets_list.py
+++ b/apps/content/api/internal/assets_list.py
@@ -21,12 +21,18 @@ class ListAssetPublisherOut(Schema):
     name: str
 
 
+class ListAssetReciterOut(Schema):
+    id: int
+    name: str
+
+
 class ListAssetOut(Schema):
     id: int
     category: str
     name: str
     description: str
     publisher: ListAssetPublisherOut = Field(alias="publisher")
+    reciter: ListAssetReciterOut | None = None
     license: LicenseChoice
     is_open_access: bool
 
@@ -35,6 +41,7 @@ class AssetFilter(FilterSchema):
     category: Annotated[list[CategoryChoice] | None, FilterLookup(q="category__in")] = None
     license_code: Annotated[list[str] | None, FilterLookup(q="license__in")] = None
     publisher_id: Annotated[int | None, FilterLookup(q="publisher")] = None
+    reciter_id: Annotated[int | None, FilterLookup(q="reciter")] = None
     is_open_access: Annotated[bool | None, FilterLookup(q="is_open_access")] = None
 
 

--- a/apps/content/api/internal/reciter_detail.py
+++ b/apps/content/api/internal/reciter_detail.py
@@ -1,0 +1,62 @@
+import datetime
+from typing import Literal
+
+from django.db.models import Count, Q
+from django.utils.translation import gettext_lazy as _
+from ninja import Field, Schema
+from pydantic import AwareDatetime
+
+from apps.content.models import CategoryChoice, Reciter, StatusChoice
+from apps.core.ninja_utils.errors import ItqanError, NinjaErrorResponse
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+from apps.core.ninja_utils.types import AbsoluteUrl
+
+router = ItqanRouter(tags=[NinjaTag.RECITERS])
+
+
+class ReciterDetailOut(Schema):
+    id: int
+    name_ar: str | None
+    name_en: str | None
+    bio_ar: str | None
+    bio_en: str | None
+    recitations_count: int = Field(0, description="Number of READY recitation assets for this reciter")
+    nationality: str | None = Field(None, description="2-letter ISO country code")
+    slug: str
+    image_url: AbsoluteUrl | None
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    date_of_death: datetime.date | None = None
+
+    @staticmethod
+    def resolve_nationality(obj: Reciter) -> str | None:
+        if obj.nationality and hasattr(obj.nationality, "code"):
+            return obj.nationality.code
+        return obj.nationality if isinstance(obj.nationality, str) else None
+
+
+@router.get(
+    "reciters/{reciter_slug}/",
+    response={
+        200: ReciterDetailOut,
+        404: NinjaErrorResponse[Literal["reciter_not_found"]],
+    },
+    auth=None,
+)
+def get_reciter(request: Request, reciter_slug: str):
+    try:
+        return Reciter.objects.annotate(
+            recitations_count=Count(
+                "assets",
+                filter=Q(assets__category=CategoryChoice.RECITATION, assets__status=StatusChoice.READY),
+                distinct=True,
+            )
+        ).get(slug=reciter_slug, is_active=True)
+    except Reciter.DoesNotExist as exc:
+        raise ItqanError(
+            error_name="reciter_not_found",
+            message=_("Reciter with slug {slug} not found.").format(slug=reciter_slug),
+            status_code=404,
+        ) from exc

--- a/apps/content/api/internal/reciter_list.py
+++ b/apps/content/api/internal/reciter_list.py
@@ -23,18 +23,26 @@ class ReciterOut(Schema):
     slug: str
     bio: str
     recitations_count: int = Field(0, description="Number of READY recitation assets for this reciter")
+    nationality: str | None = Field(None, description="2-letter ISO country code")
     image_url: AbsoluteUrl | None
     created_at: AwareDatetime
     updated_at: AwareDatetime
+
+    @staticmethod
+    def resolve_nationality(obj) -> str | None:
+        if obj.nationality and hasattr(obj.nationality, "code"):
+            return obj.nationality.code
+        return obj.nationality if isinstance(obj.nationality, str) else None
 
 
 class ReciterFilter(FilterSchema):
     name: Annotated[list[str] | None, FilterLookup(q="name__in")] = None
     name_ar: Annotated[list[str] | None, FilterLookup(q="name_ar__in")] = None
     slug: Annotated[list[str] | None, FilterLookup(q="slug__in")] = None
+    nationality: Annotated[str | None, FilterLookup(q="nationality")] = None
 
 
-@router.get("reciters/", response=list[ReciterOut])
+@router.get("reciters/", response=list[ReciterOut], auth=None)
 @paginate
 @ordering(ordering_fields=["name", "name_ar", "name_en", "created_at", "updated_at"])
 @searching(search_fields=["name", "name_en", "name_ar", "slug"])

--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -265,6 +265,8 @@ class RecitationRepository(BaseRecitationRepository):
                 qs = qs.filter(name_ar__in=names_ar)
             if slugs := filters_dict.get("slug__in"):
                 qs = qs.filter(slug__in=slugs)
+            if nationality := filters_dict.get("nationality"):
+                qs = qs.filter(nationality=nationality)
 
         return qs
 

--- a/apps/content/tests/internal/test_assets_detail.py
+++ b/apps/content/tests/internal/test_assets_detail.py
@@ -402,3 +402,43 @@ class DetailAssetTest(BaseTestCase):
         # Assert
         self.assertEqual(200, response.status_code, response.content)
         self.assertIn("access_status", response.json())
+
+    def test_detail_assets_where_recitation_should_include_reciter_field(self):
+        # Arrange
+        reciter = baker.make("content.Reciter", name="Muhammad Refaat")
+        asset = baker.make(
+            Asset,
+            name="Recitation Asset",
+            description="desc",
+            category=CategoryChoice.RECITATION,
+            license=LicenseChoice.CC0,
+            reciter=reciter,
+            riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            status=StatusChoice.READY,
+        )
+
+        # Act
+        response = self.client.get(f"/cms-api/assets/{asset.id}/", format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual({"id": reciter.id, "name": "Muhammad Refaat"}, body["reciter"])
+
+    def test_detail_assets_where_not_recitation_should_have_null_reciter(self):
+        # Arrange
+        asset = baker.make(
+            Asset,
+            name="Tafsir Asset",
+            description="desc",
+            category=CategoryChoice.TAFSIR,
+            license=LicenseChoice.CC0,
+            status=StatusChoice.READY,
+        )
+
+        # Act
+        response = self.client.get(f"/cms-api/assets/{asset.id}/", format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertIsNone(response.json()["reciter"])

--- a/apps/content/tests/internal/test_assets_list.py
+++ b/apps/content/tests/internal/test_assets_list.py
@@ -343,3 +343,70 @@ class ListAssetTest(BaseTestCase):
         body = response.json()
         self.assertEqual(5, body["count"])
         self.assertEqual(5, len(body["results"]))
+
+    # ── Reciter ───────────────────────────────────────────────
+
+    def test_list_asset_where_recitation_should_include_reciter_field(self):
+        # Arrange
+        reciter = baker.make("content.Reciter", name="Muhammad Refaat")
+        baker.make(
+            Asset,
+            name="Recitation Asset",
+            category=CategoryChoice.RECITATION,
+            reciter=reciter,
+            riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+            status=StatusChoice.READY,
+        )
+
+        # Act
+        response = self.client.get("/cms-api/assets/", format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, len(body["results"]))
+        self.assertEqual({"id": reciter.id, "name": "Muhammad Refaat"}, body["results"][0]["reciter"])
+
+    def test_list_asset_where_not_recitation_should_have_null_reciter(self):
+        # Arrange
+        baker.make(Asset, name="Tafsir Asset", category=CategoryChoice.TAFSIR, status=StatusChoice.READY)
+
+        # Act
+        response = self.client.get("/cms-api/assets/", format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, len(body["results"]))
+        self.assertIsNone(body["results"][0]["reciter"])
+
+    def test_list_asset_filter_by_reciter_id_should_return_only_that_reciters_assets(self):
+        # Arrange
+        target_reciter = baker.make("content.Reciter", name="Target Reciter")
+        other_reciter = baker.make("content.Reciter", name="Other Reciter")
+        riwayah = baker.make("content.Riwayah", name="Test Riwayah")
+        baker.make(
+            Asset,
+            name="Target Recitation",
+            category=CategoryChoice.RECITATION,
+            reciter=target_reciter,
+            riwayah=riwayah,
+            status=StatusChoice.READY,
+        )
+        baker.make(
+            Asset,
+            name="Other Recitation",
+            category=CategoryChoice.RECITATION,
+            reciter=other_reciter,
+            riwayah=riwayah,
+            status=StatusChoice.READY,
+        )
+
+        # Act
+        response = self.client.get("/cms-api/assets/", data={"reciter_id": target_reciter.id}, format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, len(body["results"]))
+        self.assertEqual("Target Recitation", body["results"][0]["name"])

--- a/apps/content/tests/internal/test_reciter_detail.py
+++ b/apps/content/tests/internal/test_reciter_detail.py
@@ -1,0 +1,111 @@
+from model_bakery import baker
+
+from apps.content.models import Asset, CategoryChoice, Reciter, StatusChoice
+from apps.core.tests.base import BaseTestCase
+
+
+class ReciterDetailTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.reciter = Reciter.objects.create(
+            name="Test Reciter",
+            name_en="Test Reciter",
+            name_ar="مقرئ تجريبي",
+            slug="test-reciter",
+            bio_en="Test Bio",
+            bio_ar="سيرة تجريبية",
+            nationality="SA",
+        )
+
+    def test_get_reciter_where_exists_should_return_200(self):
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{self.reciter.slug}/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(self.reciter.id, body["id"])
+        self.assertEqual("Test Reciter", body["name_en"])
+        self.assertEqual("مقرئ تجريبي", body["name_ar"])
+        self.assertEqual("Test Bio", body["bio_en"])
+        self.assertEqual("سيرة تجريبية", body["bio_ar"])
+        self.assertEqual("test-reciter", body["slug"])
+        self.assertEqual("SA", body["nationality"])
+        self.assertIn("created_at", body)
+        self.assertIn("updated_at", body)
+
+    def test_get_reciter_where_unauthenticated_should_return_200(self):
+        # Arrange — no authenticate_user() call: client stays anonymous
+
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{self.reciter.slug}/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+
+    def test_get_reciter_where_non_existent_slug_should_return_404(self):
+        # Act
+        response = self.client.get("/cms-api/reciters/does-not-exist/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("reciter_not_found", response.json()["error_name"])
+
+    def test_get_reciter_where_inactive_should_return_404(self):
+        # Arrange — inactive reciters must not be publicly viewable, matching the list endpoint
+        inactive_reciter = baker.make(Reciter, name="Inactive Reciter", slug="inactive-reciter", is_active=False)
+
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{inactive_reciter.slug}/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("reciter_not_found", response.json()["error_name"])
+
+    def test_get_reciter_where_nationality_missing_should_return_null(self):
+        # Arrange
+        reciter = baker.make(Reciter, name="No Nationality Reciter", slug="no-nationality-reciter")
+
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{reciter.slug}/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertIsNone(response.json()["nationality"])
+
+    def test_get_reciter_recitations_count_should_only_count_ready_recitation_assets(self):
+        # Arrange
+        riwayah = baker.make("content.Riwayah", name="Test Riwayah")
+        baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            reciter=self.reciter,
+            riwayah=riwayah,
+            status=StatusChoice.READY,
+        )
+        baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            reciter=self.reciter,
+            riwayah=riwayah,
+            status=StatusChoice.DRAFT,
+        )
+
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{self.reciter.slug}/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual(1, response.json()["recitations_count"])
+
+    def test_get_reciter_where_date_of_death_present_should_be_returned(self):
+        # Arrange
+        self.reciter.date_of_death = "2020-01-15"
+        self.reciter.save()
+
+        # Act
+        response = self.client.get(f"/cms-api/reciters/{self.reciter.slug}/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual("2020-01-15", response.json()["date_of_death"])

--- a/apps/content/tests/internal/test_reciter_list.py
+++ b/apps/content/tests/internal/test_reciter_list.py
@@ -151,3 +151,56 @@ class RecitersListTest(BaseTestCase):
         body = response.json()
         self.assertEqual(1, body["count"])
         self.assertEqual("مشاري راشد العفاسي", body["results"][0]["name"])
+
+    def test_list_reciters_where_unauthenticated_should_return_200(self):
+        # Arrange — no self.authenticate_user() call: client stays anonymous
+
+        # Act
+        response = self.client.get("/cms-api/reciters/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        reciter_names = {item["name"] for item in response.json()["results"]}
+        self.assertIn("Active Reciter", reciter_names)
+
+    def test_list_reciters_should_include_nationality_field(self):
+        # Arrange
+        self._make_reciter_with_recitation(name="Saudi Reciter", is_active=True, nationality="SA")
+        self.authenticate_user(self.user)
+
+        # Act
+        response = self.client.get("/cms-api/reciters/", data={"search": "Saudi Reciter"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("SA", body["results"][0]["nationality"])
+
+    def test_list_reciters_where_nationality_missing_should_return_null(self):
+        # Arrange — self.active_reciter (created in setUp) has no nationality set
+        self.authenticate_user(self.user)
+
+        # Act
+        response = self.client.get("/cms-api/reciters/", data={"search": "Active Reciter"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertIsNone(body["results"][0]["nationality"])
+
+    def test_list_reciters_filter_by_nationality_should_return_only_matching_reciters(self):
+        # Arrange
+        self._make_reciter_with_recitation(name="Saudi Reciter", is_active=True, nationality="SA")
+        self._make_reciter_with_recitation(name="Egyptian Reciter", is_active=True, nationality="EG")
+        self.authenticate_user(self.user)
+
+        # Act
+        response = self.client.get("/cms-api/reciters/", data={"nationality": "EG"})
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, body["count"])
+        self.assertEqual("Egyptian Reciter", body["results"][0]["name"])

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -23,16 +23,16 @@ msgid "You do not have access to this asset"
 msgstr "ليس لديك صلاحية الوصول إلى هذا المورد"
 
 #, python-brace-format
+msgid "Reciter with slug {slug} not found."
+msgstr "لم يتم العثور على القارئ بالمعرّف {slug}."
+
+#, python-brace-format
 msgid "Asset with slug {slug} not found."
 msgstr "المورد ذو المعرف {slug} غير موجود."
 
 #, python-brace-format
 msgid "Recitation with slug {slug} not found."
 msgstr "لم يتم العثور على التلاوة بالمعرّف {slug}."
-
-#, python-brace-format
-msgid "Reciter with slug {slug} not found."
-msgstr "لم يتم العثور على القارئ بالمعرّف {slug}."
 
 #, python-brace-format
 msgid "Tafsir with slug {slug} not found."


### PR DESCRIPTION
## Summary
Scoped promotion of the reciters SEO work (already merged to staging via #395) into main — cherry-picked, not a full staging→main merge, since staging is currently far ahead of main with unrelated work.

- Makes `/cms-api/reciters/` list endpoint public (`auth=None`) and adds a `nationality` field + filter
- Adds `GET /cms-api/reciters/{slug}/` detail endpoint (public-safe subset of the portal admin serializer)
- Adds `reciter` field + `reciter_id` filter to `/cms-api/assets/` (list + detail) — `Asset.reciter` FK already existed, no migration

## Context
Backend half of the "Add SEO for search for reciters" story. Companion frontend PR: itqan-community/cms-frontend#202 (also being promoted to master separately).

## Test plan
- [x] 16 new tests (TDD), full suite 789 passed / 57 skipped / 0 failures on this branch
- [x] `ruff`, `black`, `manage.py check`, and the ar locale check all clean
- [x] No migration needed

**This PR is NOT merged and should not be auto-merged — opened for review only.**