### PR TITLE
fix: health-check staging pushes against staging API, not production

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -4,6 +4,16 @@ on:
     branches: [main, staging]
 
 jobs:
-  check:
+  check-staging:
+    if: github.ref_name == 'staging'
     uses: Itqan-community/.github/.github/workflows/health-check.yml@main
+    with:
+      url: https://staging.api.cms.itqan.dev/health/
+    secrets: inherit
+
+  check-production:
+    if: github.ref_name == 'main'
+    uses: Itqan-community/.github/.github/workflows/health-check.yml@main
+    with:
+      url: https://api.cms.itqan.dev/health/
     secrets: inherit


### PR DESCRIPTION
## Summary

Post-Deploy Health Check ran a single job for both `main` and `staging` pushes, and always checked `HEALTH_CHECK_URL` (the production secret). A push to `staging` therefore health-checked `https://api.cms.itqan.dev/health/` instead of the staging deploy, which caused a false-alarm Slack alert when production had a transient blip unrelated to the staging deploy — and meant staging's own health was never actually verified.

## Change

Splits the single `check` job into two, gated by `github.ref_name`, each passing an explicit `url` to the shared reusable workflow:

- `staging` push → `check-staging` → `https://staging.api.cms.itqan.dev/health/`
- `main` push → `check-production` → `https://api.cms.itqan.dev/health/`

Staging domain confirmed from `config/settings/staging.py` (`ALLOWED_HOSTS`). No new secret needed — the URLs are hardcoded inputs (not sensitive).

## Dependency

**Requires Itqan-community/.github#2 to be merged first.** This PR passes a `url` input to `Itqan-community/.github/.github/workflows/health-check.yml@main`; that input doesn't exist on `main` of the `.github` repo yet. Until that PR merges, this workflow's `with: url:` will be silently ignored by the reusable workflow (older version has no `url` input) and it'll keep falling back to the `HEALTH_CHECK_URL` secret — not a hard failure, but also not the fix. Please merge Itqan-community/.github#2 before (or immediately after) merging this one.

## Test plan
- [x] `actionlint` clean
- [x] Manual YAML review
- [ ] Confirm staging push resolves to `staging.api.cms.itqan.dev` health check after both PRs merge
- [ ] Confirm main push still resolves to `api.cms.itqan.dev`