### PR TITLE
feat: add support for file upload with versioning in asset creation APIs

### DIFF
--- a/apps/content/api/portal/fonts.py
+++ b/apps/content/api/portal/fonts.py
@@ -114,6 +114,8 @@ class FontCreateIn(Schema):
     external_url: str | None = None
     is_open_access: bool = False
     restricted_for_tenant: bool = False
+    version_name: str | None = Field(default=None, max_length=255)
+    version_summary: str = ""
 
 
 class FontPutIn(Schema):
@@ -200,7 +202,9 @@ def list_fonts(request: Request, filters: FontFilter = Query()):
     "fonts/",
     response={
         201: FontDetailOut,
-        400: NinjaErrorResponse[Literal["font_name_required"]] | NinjaErrorResponse[Literal["external_url_required"]],
+        400: NinjaErrorResponse[Literal["font_name_required"]]
+        | NinjaErrorResponse[Literal["external_url_required"]]
+        | NinjaErrorResponse[Literal["version_name_required"]],
         404: NinjaErrorResponse[Literal["publisher_not_found"]] | NinjaErrorResponse[Literal["font_not_found"]],
     },
 )
@@ -209,13 +213,17 @@ def create_font(
     request: Request,
     data: Form[FontCreateIn],
     thumbnail: UploadedFile | None = File(None),
+    file: UploadedFile | None = File(None),
 ) -> tuple[int, Asset]:
     logger.info(
         f"Creating font [publisher_id={data.publisher_id}, language={data.language}, user_id={request.user.id}]"
     )
     enforce_publisher_membership(request.user, data.publisher_id)
     service = FontService()
-    font = service.create_font(
+    font = service.create_font_with_optional_version(
+        version_name=data.version_name,
+        version_summary=data.version_summary,
+        file=file,
         publisher_id=data.publisher_id,
         name_ar=data.name_ar,
         name_en=data.name_en,

--- a/apps/content/api/portal/mushafs.py
+++ b/apps/content/api/portal/mushafs.py
@@ -114,6 +114,8 @@ class MushafCreateIn(Schema):
     external_url: str | None = None
     is_open_access: bool = False
     restricted_for_tenant: bool = False
+    version_name: str | None = Field(default=None, max_length=255)
+    version_summary: str = ""
 
 
 class MushafPutIn(Schema):
@@ -200,7 +202,9 @@ def list_mushafs(request: Request, filters: MushafFilter = Query()):
     "mushafs/",
     response={
         201: MushafDetailOut,
-        400: NinjaErrorResponse[Literal["mushaf_name_required"]] | NinjaErrorResponse[Literal["external_url_required"]],
+        400: NinjaErrorResponse[Literal["mushaf_name_required"]]
+        | NinjaErrorResponse[Literal["external_url_required"]]
+        | NinjaErrorResponse[Literal["version_name_required"]],
         404: NinjaErrorResponse[Literal["publisher_not_found"]] | NinjaErrorResponse[Literal["mushaf_not_found"]],
     },
 )
@@ -209,13 +213,17 @@ def create_mushaf(
     request: Request,
     data: Form[MushafCreateIn],
     thumbnail: UploadedFile | None = File(None),
+    file: UploadedFile | None = File(None),
 ) -> tuple[int, Asset]:
     logger.info(
         f"Creating mushaf [publisher_id={data.publisher_id}, language={data.language}, user_id={request.user.id}]"
     )
     enforce_publisher_membership(request.user, data.publisher_id)
     service = MushafService()
-    mushaf = service.create_mushaf(
+    mushaf = service.create_mushaf_with_optional_version(
+        version_name=data.version_name,
+        version_summary=data.version_summary,
+        file=file,
         publisher_id=data.publisher_id,
         name_ar=data.name_ar,
         name_en=data.name_en,

--- a/apps/content/api/portal/tafsirs.py
+++ b/apps/content/api/portal/tafsirs.py
@@ -114,6 +114,8 @@ class TafsirCreateIn(Schema):
     external_url: str | None = None
     is_open_access: bool = False
     restricted_for_tenant: bool = False
+    version_name: str | None = Field(default=None, max_length=255)
+    version_summary: str = ""
 
 
 class TafsirPutIn(Schema):
@@ -200,7 +202,9 @@ def list_tafsirs(request: Request, filters: TafsirFilter = Query()):
     "tafsirs/",
     response={
         201: TafsirDetailOut,
-        400: NinjaErrorResponse[Literal["tafsir_name_required"]] | NinjaErrorResponse[Literal["external_url_required"]],
+        400: NinjaErrorResponse[Literal["tafsir_name_required"]]
+        | NinjaErrorResponse[Literal["external_url_required"]]
+        | NinjaErrorResponse[Literal["version_name_required"]],
         404: NinjaErrorResponse[Literal["publisher_not_found"]] | NinjaErrorResponse[Literal["tafsir_not_found"]],
     },
 )
@@ -209,13 +213,17 @@ def create_tafsir(
     request: Request,
     data: Form[TafsirCreateIn],
     thumbnail: UploadedFile | None = File(None),
+    file: UploadedFile | None = File(None),
 ) -> tuple[int, Asset]:
     logger.info(
         f"Creating tafsir [publisher_id={data.publisher_id}, language={data.language}, user_id={request.user.id}]"
     )
     enforce_publisher_membership(request.user, data.publisher_id)
     service = TafsirService()
-    tafsir = service.create_tafsir(
+    tafsir = service.create_tafsir_with_optional_version(
+        version_name=data.version_name,
+        version_summary=data.version_summary,
+        file=file,
         publisher_id=data.publisher_id,
         name_ar=data.name_ar,
         name_en=data.name_en,

--- a/apps/content/api/portal/translations.py
+++ b/apps/content/api/portal/translations.py
@@ -2,7 +2,7 @@ import logging
 from typing import Annotated, Literal
 
 from django.utils.translation import gettext_lazy as _
-from ninja import FilterLookup, FilterSchema, Query, Schema
+from ninja import File, FilterLookup, FilterSchema, Form, Query, Schema, UploadedFile
 from ninja.pagination import paginate
 from pydantic import AwareDatetime, Field
 
@@ -108,6 +108,8 @@ class TranslationCreateIn(Schema):
     external_url: str | None = None
     is_open_access: bool = False
     restricted_for_tenant: bool = False
+    version_name: str | None = Field(default=None, max_length=255)
+    version_summary: str = ""
 
 
 class TranslationPutIn(Schema):
@@ -185,21 +187,26 @@ def list_translations(request: Request, filters: TranslationFilter = Query()):
     response={
         201: TranslationDetailOut,
         400: NinjaErrorResponse[Literal["translation_name_required"]]
-        | NinjaErrorResponse[Literal["external_url_required"]],
+        | NinjaErrorResponse[Literal["external_url_required"]]
+        | NinjaErrorResponse[Literal["version_name_required"]],
         404: NinjaErrorResponse[Literal["publisher_not_found"]],
     },
 )
 @permission_required([permission_class(PermissionChoice.PORTAL_CREATE_TRANSLATION)])
 def create_translation(
     request: Request,
-    data: TranslationCreateIn,
+    data: Form[TranslationCreateIn],
+    file: UploadedFile | None = File(None),
 ) -> tuple[int, Asset]:
     logger.info(
         f"Creating translation [publisher_id={data.publisher_id}, language={data.language}, user_id={request.user.id}]"
     )
     enforce_publisher_membership(request.user, data.publisher_id)
     service = TranslationService()
-    translation = service.create_translation(
+    translation = service.create_translation_with_optional_version(
+        version_name=data.version_name,
+        version_summary=data.version_summary,
+        file=file,
         publisher_id=data.publisher_id,
         name_ar=data.name_ar,
         name_en=data.name_en,

--- a/apps/content/services/font.py
+++ b/apps/content/services/font.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.db import transaction
 from django.db.models import ProtectedError, Q
 from django.utils.translation import gettext as _
 
@@ -108,6 +109,39 @@ class FontService:
             restricted_for_tenant=restricted_for_tenant,
         )
         logger.info(f"Font created [asset_id={font.pk}, publisher_id={publisher_id}, language={language}]")
+        return font
+
+    def create_font_with_optional_version(
+        self,
+        *,
+        version_name: str | None = None,
+        version_summary: str = "",
+        file: Any = None,
+        **font_kwargs: Any,
+    ) -> Asset:
+        """
+        Business Logic: Create a font and, when a file is provided, its first
+        version in a single atomic transaction.
+
+        ``font_kwargs`` are forwarded verbatim to :meth:`create_font`.
+        """
+        if file is not None and not (version_name or "").strip():
+            raise ItqanError(
+                error_name="version_name_required",
+                message=_("Version name is required when a file is provided."),
+                status_code=400,
+            )
+
+        with transaction.atomic():
+            font = self.create_font(**font_kwargs)
+            if file is not None:
+                self.create_font_version(
+                    font.slug,
+                    name=version_name or "",
+                    summary=version_summary,
+                    file=file,
+                )
+        font.refresh_from_db()
         return font
 
     def update_font(

--- a/apps/content/services/mushaf.py
+++ b/apps/content/services/mushaf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.db import transaction
 from django.db.models import ProtectedError, Q
 from django.utils.translation import gettext as _
 
@@ -108,6 +109,39 @@ class MushafService:
             restricted_for_tenant=restricted_for_tenant,
         )
         logger.info(f"Mushaf created [asset_id={mushaf.pk}, publisher_id={publisher_id}, language={language}]")
+        return mushaf
+
+    def create_mushaf_with_optional_version(
+        self,
+        *,
+        version_name: str | None = None,
+        version_summary: str = "",
+        file: Any = None,
+        **mushaf_kwargs: Any,
+    ) -> Asset:
+        """
+        Business Logic: Create a mushaf and, when a file is provided, its first
+        version in a single atomic transaction.
+
+        ``mushaf_kwargs`` are forwarded verbatim to :meth:`create_mushaf`.
+        """
+        if file is not None and not (version_name or "").strip():
+            raise ItqanError(
+                error_name="version_name_required",
+                message=_("Version name is required when a file is provided."),
+                status_code=400,
+            )
+
+        with transaction.atomic():
+            mushaf = self.create_mushaf(**mushaf_kwargs)
+            if file is not None:
+                self.create_mushaf_version(
+                    mushaf.slug,
+                    name=version_name or "",
+                    summary=version_summary,
+                    file=file,
+                )
+        mushaf.refresh_from_db()
         return mushaf
 
     def update_mushaf(

--- a/apps/content/services/tafsir.py
+++ b/apps/content/services/tafsir.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.db import transaction
 from django.db.models import ProtectedError, Q
 from django.utils.translation import gettext as _
 
@@ -108,6 +109,39 @@ class TafsirService:
             restricted_for_tenant=restricted_for_tenant,
         )
         logger.info(f"Tafsir created [asset_id={tafsir.pk}, publisher_id={publisher_id}, language={language}]")
+        return tafsir
+
+    def create_tafsir_with_optional_version(
+        self,
+        *,
+        version_name: str | None = None,
+        version_summary: str = "",
+        file: Any = None,
+        **tafsir_kwargs: Any,
+    ) -> Asset:
+        """
+        Business Logic: Create a tafsir and, when a file is provided, its first
+        version in a single atomic transaction.
+
+        ``tafsir_kwargs`` are forwarded verbatim to :meth:`create_tafsir`.
+        """
+        if file is not None and not (version_name or "").strip():
+            raise ItqanError(
+                error_name="version_name_required",
+                message=_("Version name is required when a file is provided."),
+                status_code=400,
+            )
+
+        with transaction.atomic():
+            tafsir = self.create_tafsir(**tafsir_kwargs)
+            if file is not None:
+                self.create_tafsir_version(
+                    tafsir.slug,
+                    name=version_name or "",
+                    summary=version_summary,
+                    file=file,
+                )
+        tafsir.refresh_from_db()
         return tafsir
 
     def update_tafsir(

--- a/apps/content/services/translation.py
+++ b/apps/content/services/translation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.db import transaction
 from django.db.models import ProtectedError, Q
 from django.utils.translation import gettext as _
 
@@ -108,6 +109,39 @@ class TranslationService:
         logger.info(
             f"Translation created [asset_id={translation.pk}, publisher_id={publisher_id}, language={language}]"
         )
+        return translation
+
+    def create_translation_with_optional_version(
+        self,
+        *,
+        version_name: str | None = None,
+        version_summary: str = "",
+        file: Any = None,
+        **translation_kwargs: Any,
+    ) -> Asset:
+        """
+        Business Logic: Create a translation and, when a file is provided, its
+        first version in a single atomic transaction.
+
+        ``translation_kwargs`` are forwarded verbatim to :meth:`create_translation`.
+        """
+        if file is not None and not (version_name or "").strip():
+            raise ItqanError(
+                error_name="version_name_required",
+                message=_("Version name is required when a file is provided."),
+                status_code=400,
+            )
+
+        with transaction.atomic():
+            translation = self.create_translation(**translation_kwargs)
+            if file is not None:
+                self.create_translation_version(
+                    translation.slug,
+                    name=version_name or "",
+                    summary=version_summary,
+                    file=file,
+                )
+        translation.refresh_from_db()
         return translation
 
     def update_translation(

--- a/apps/content/tests/portal/fonts/test_fonts_create.py
+++ b/apps/content/tests/portal/fonts/test_fonts_create.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
-from apps.content.models import Asset, CategoryChoice, StatusChoice
+from apps.content.models import Asset, AssetVersion, CategoryChoice, StatusChoice
 from apps.core.permissions import PermissionChoice
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher
@@ -294,6 +294,89 @@ class FontCreateTest(BaseTestCase):
         asset = Asset.objects.get(id=body["id"])
         self.assertTrue(asset.is_open_access)
         self.assertTrue(asset.restricted_for_tenant)
+
+    def test_create_font_where_file_and_version_name_provided_should_create_asset_and_version(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        self.give_permission(self.user, PermissionChoice.PORTAL_CREATE_FONT)
+        file = SimpleUploadedFile("font.pdf", b"font_bytes", content_type="application/pdf")
+
+        # Act
+        response = self.client.post(
+            "/portal/fonts/",
+            data={
+                "name_en": "Font With Version",
+                "license": "CC-BY",
+                "language": "ar",
+                "publisher_id": self.publisher.id,
+                "is_external": False,
+                "version_name": "1.0.0",
+                "version_summary": "Initial release",
+                "file": file,
+            },
+        )
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual(1, len(body["versions"]))
+        self.assertEqual("1.0.0", body["versions"][0]["name"])
+        self.assertIsNotNone(body["versions"][0]["file_url"])
+
+        asset = Asset.objects.get(id=body["id"])
+        version = AssetVersion.objects.get(asset=asset)
+        self.assertEqual("1.0.0", version.name)
+        self.assertEqual(len(b"font_bytes"), version.size_bytes)
+
+    def test_create_font_where_file_without_version_name_should_return_400(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        self.give_permission(self.user, PermissionChoice.PORTAL_CREATE_FONT)
+        file = SimpleUploadedFile("font.pdf", b"font_bytes", content_type="application/pdf")
+
+        # Act
+        response = self.client.post(
+            "/portal/fonts/",
+            data={
+                "name_en": "Font Missing Version Name",
+                "license": "CC-BY",
+                "language": "ar",
+                "publisher_id": self.publisher.id,
+                "is_external": False,
+                "file": file,
+            },
+        )
+
+        # Assert
+        self.assertEqual(400, response.status_code, response.content)
+        self.assertEqual("version_name_required", response.json()["error_name"])
+        # Asset must not be persisted (atomic rollback)
+        self.assertFalse(Asset.objects.filter(name="Font Missing Version Name").exists())
+
+    def test_create_font_where_no_file_provided_should_create_asset_without_version(self):
+        # Arrange
+        self.authenticate_user(self.user)
+        self.give_permission(self.user, PermissionChoice.PORTAL_CREATE_FONT)
+
+        # Act
+        response = self.client.post(
+            "/portal/fonts/",
+            data={
+                "name_en": "Font Without Version",
+                "license": "CC-BY",
+                "language": "ar",
+                "publisher_id": self.publisher.id,
+                "is_external": False,
+                "version_name": "ignored-without-file",
+            },
+        )
+
+        # Assert
+        self.assertEqual(201, response.status_code, response.content)
+        body = response.json()
+        self.assertEqual([], body["versions"])
+        asset = Asset.objects.get(id=body["id"])
+        self.assertFalse(AssetVersion.objects.filter(asset=asset).exists())
 
     def test_create_font_where_user_lacks_permission_should_return_403(self):
         # Arrange

--- a/apps/content/tests/portal/translations/test_translations_create.py
+++ b/apps/content/tests/portal/translations/test_translations_create.py
@@ -29,9 +29,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(201, response.status_code, response.content)
@@ -63,7 +61,6 @@ class TranslationCreateTest(BaseTestCase):
                 "publisher_id": self.publisher.id,
                 "is_external": False,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(201, response.status_code, response.content)
@@ -88,7 +85,6 @@ class TranslationCreateTest(BaseTestCase):
                 "is_open_access": True,
                 "restricted_for_tenant": True,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(201, response.status_code, response.content)
@@ -115,9 +111,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": 99999,  # Non-existent publisher
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(404, response.status_code, response.content)
@@ -140,9 +134,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(400, response.status_code, response.content)
@@ -163,9 +155,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(401, response.status_code, response.content)
@@ -186,9 +176,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
 
         self.assertEqual(201, response.status_code, response.content)
@@ -209,7 +197,6 @@ class TranslationCreateTest(BaseTestCase):
                 "is_external": True,
                 "external_url": "https://example.com/translation",
             },
-            content_type="application/json",
         )
 
         self.assertEqual(201, response.status_code, response.content)
@@ -231,7 +218,6 @@ class TranslationCreateTest(BaseTestCase):
                 "is_external": True,
                 "external_url": "",  # explicitly empty/absent
             },
-            content_type="application/json",
         )
 
         self.assertEqual(400, response.status_code, response.content)
@@ -256,9 +242,7 @@ class TranslationCreateTest(BaseTestCase):
                 "language": "en",
                 "publisher_id": self.publisher.id,
                 "is_external": False,
-                "external_url": None,
             },
-            content_type="application/json",
         )
         self.assertEqual(403, response.status_code)
         self.assertEqual("permission_denied", response.json()["error_name"])

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -191,6 +191,9 @@ msgstr "اسم الخط (بالعربية أو الإنجليزية) مطلوب.
 msgid "External URL is required when is_external is True."
 msgstr "الرابط الخارجي مطلوب عندما يكون المصدري خارجي."
 
+msgid "Version name is required when a file is provided."
+msgstr "اسم الإصدار مطلوب عند تقديم ملف."
+
 msgid "Cannot delete Font because they are referenced through other objects"
 msgstr "لا يمكن حذف الخط لأن هناك بيانات أخرى مرتبطة به"
 


### PR DESCRIPTION
Introduced optional `version_name` and `version_summary` fields for assets creation, allowing initial version creation when a file is provided. Ensured atomic rollback for invalid inputs and updated tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional version names, summaries, and file uploads when creating fonts, mushafs, tafsirs, and translations.
  * Uploaded files can now create an initial version alongside the asset.
  * Added validation requiring a version name when a file is uploaded.

* **Bug Fixes**
  * Asset and version creation now completes atomically, preventing incomplete records after errors.

* **Documentation**
  * Added Arabic localization for the missing version name validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->