### PR TITLE
fix: bounded gunicorn concurrency (WSGI/gthread) to stop prod OOM

### DIFF
--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -33,9 +33,12 @@ if [ "${RUN_PREP:-0}" = "1" ]; then
     python manage.py compilemessages --locale ar
 fi
 
-echo "Starting Gunicorn (ASGI, Uvicorn workers)..."
-exec gunicorn config.asgi:application \
+echo "Starting Gunicorn (WSGI, gthread workers)..."
+exec gunicorn config.wsgi:application \
     --bind 0.0.0.0:8000 \
-    --workers "${GUNICORN_WORKERS:-10}" \
-    --worker-class config.workers.DjangoUvicornWorker \
-    --timeout 600
+    --workers "${GUNICORN_WORKERS:-6}" \
+    --worker-class gthread \
+    --threads "${GUNICORN_THREADS:-4}" \
+    --max-requests 1000 \
+    --max-requests-jitter 100 \
+    --timeout 60


### PR DESCRIPTION
## Summary
- Prod OOM'd from unbounded per-request thread growth under the ASGI/uvicorn gunicorn worker; switches to WSGI + bounded `gthread` workers (6 workers x 4 threads) plus `--max-requests` recycling and a shorter timeout.

## Verification
- Built the real production Dockerfile image on this branch and ran it against Postgres/Redis/RabbitMQ with the actual new `entrypoint.sh` (WSGI + gthread). Confirmed gunicorn boots cleanly with 6 gthread workers.
- Hit `@paginate`/`@ordering`/`@searching`-decorated django-ninja endpoints (`/cms-api/reciters/`, `/recitations/`) directly against the running WSGI/gthread server — all returned correct `200`s with proper pagination envelopes, confirming Django Ninja's internal `async def` dispatch (`ordering_base.py`, `searching_base.py`, `paginations.py`) works correctly under `async_to_sync` on WSGI. This was the main pre-merge risk.
- Pulled 24h of real caddy access logs from prod to size `--timeout 60`: p50=3.0s, p90=3.06s, p99=31.2s, max=61.2s. Every request over 10s was already a `502` (dead backend during the current OOM instability), not legitimate slow traffic, so 60s doesn't appear to cut off real requests under current load.
- Gap: no upload/create POST traffic (`translations`, `tafsirs`, `recitations`, `mushafs`, `fonts`) appeared in the 24h sample, so large audio-file direct-upload duration under the new timeout is unverified. Worth watching after this deploys to staging.

## Test plan
- [x] Verified `@paginate`/`@ordering`/`@searching` endpoints work under gthread/WSGI (see above)
- [ ] CI passes (lint/tests)
- [ ] Deploy to staging, confirm `docker-web-1` starts healthy with `gthread` worker class
- [ ] Monitor staging memory for a few hours: should plateau instead of climbing unbounded
- [ ] Watch upload-endpoint behavior specifically (unverified timeout edge case above)
- [ ] After prod deploy, monitor for 24h to confirm no repeat of the 90%+ memory alert

Follow-up (not in this PR): rate limiting is currently non-enforcing (`throttle_failure()` returns `True`) and `/recitations/{id}/` accepts uncapped `page_size` — both likely upstream load drivers, worth a separate fix. This PR bounds the memory symptom, not the root cause of the load.

Note: since `staging` is this repo's default branch and was just merged with `main`, `staging` will diverge on this file again once this merges to `main` — needs a `main`→`staging` merge afterward or the next staging deploy runs the old ASGI entrypoint.