### PR TITLE
chore: bump gunicorn to 10 workers x 6 threads

### DIFF
--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -36,9 +36,9 @@ fi
 echo "Starting Gunicorn (WSGI, gthread workers)..."
 exec gunicorn config.wsgi:application \
     --bind 0.0.0.0:8000 \
-    --workers "${GUNICORN_WORKERS:-6}" \
+    --workers "${GUNICORN_WORKERS:-10}" \
     --worker-class gthread \
-    --threads "${GUNICORN_THREADS:-4}" \
+    --threads "${GUNICORN_THREADS:-6}" \
     --max-requests 1000 \
     --max-requests-jitter 100 \
     --timeout 60


### PR DESCRIPTION
## Summary
- Prod has been stable at 6 workers x 4 threads for 30+ min (memory flat 797-838MB, no errors) after #402. Bumping to 10 workers x 6 threads (60 concurrent slots vs 24) for more headroom, while staying well within the bounded-concurrency model that fixed the OOM.
- Sized against the 4vCPU/8GB droplet: 10 workers roughly matches the standard `2xcores+2` sync-worker guideline; threads (not workers) are the cheaper dial for extra I/O concurrency since each worker is a full process (memory duplication) while threads only add stack overhead.

## Test plan
- [ ] CI passes
- [ ] Deploy to prod (auto on merge to main), confirm `docker-web-1` boots with `--workers 10 --threads 6`
- [ ] Watch memory for 15-30min post-deploy: expect roughly proportional increase from current ~800MB baseline, should still plateau (not climb)