### PR TITLE
fix: forward real client IP (Cf-Connecting-Ip) instead of Cloudflare's edge IP

### DIFF
--- a/deployment/docker/Caddyfile
+++ b/deployment/docker/Caddyfile
@@ -19,7 +19,13 @@
     rewrite @recitation_no_trail /recitations/{re.notrail.1}/
 
     # Reverse proxy to Django application (for all other requests)
-    reverse_proxy web:8000
+    # Cloudflare sits in front of this origin; without this, Caddy stamps
+    # X-Forwarded-For with its own peer IP (Cloudflare's edge node), so every
+    # real client behind the same CF PoP shares one throttle/log identity.
+    # Cf-Connecting-Ip is Cloudflare's dedicated real-client-IP header.
+    reverse_proxy web:8000 {
+        header_up X-Forwarded-For {http.request.header.Cf-Connecting-Ip}
+    }
 
     # Security headers
     header {


### PR DESCRIPTION
## Summary
- Caddy had no override for X-Forwarded-For, so it stamped it with its own immediate peer -- Cloudflare's edge node, not the real client. Confirmed live: a real request showed `X-Forwarded-For: 172.70.111.108` (Cloudflare's edge IP) while `Cf-Connecting-Ip` carried the actual end-user IP.
- Consequence: `PublicApiAnonRateThrottle` (100/min, keyed via `get_ident()` -> `X-Forwarded-For`) was bucketing every distinct anonymous user behind the same Cloudflare PoP into one shared throttle identity -- likely causing false 429s for innocent co-located users while doing little against a genuinely abusive single client (its requests dilute into the shared bucket).
- Fix: forward `Cf-Connecting-Ip` as `X-Forwarded-For` so per-client throttling and access logs reflect real distinct clients.

## Security note (must read before merging)
This unconditionally trusts `Cf-Connecting-Ip`. The origin is reachable directly at its raw droplet IP (confirmed -- scanner/bot traffic hits `142.93.187.166` directly today, bypassing Cloudflare entirely). Anyone hitting the origin directly could set an arbitrary `Cf-Connecting-Ip` header and fully evade the throttle by rotating fake values.

**This needs a companion fix, not included here**: restrict inbound HTTP/HTTPS on the DigitalOcean firewall to Cloudflare's published IP ranges (https://www.cloudflare.com/ips/), so the origin only ever accepts connections that actually came through Cloudflare. That's infra config, not a repo change -- flagging so it doesn't get missed.

## Test plan
- [ ] CI passes
- [ ] Deploy, confirm a live request shows the real client IP (not a CF edge IP) in caddy access logs
- [ ] Re-run per-client request-rate analysis on fresh logs to size throttle rates against real client identities
- [ ] Track the DO firewall CF-IP-range restriction as a follow-up (not in this PR)