### PR TITLE
hotfix: restore Cloudflare Origin CA cert config, fix Caddyfile bind-mount drift

### DIFF
--- a/deployment/docker/Caddyfile
+++ b/deployment/docker/Caddyfile
@@ -1,4 +1,11 @@
 {$SITE_DOMAIN} {
+    # Cloudflare Origin CA cert (manually provisioned 2026-07-09, files live in
+    # the persistent caddy_data volume at /data/cf-origin/). Was previously
+    # only added by hand directly on the box, never committed here -- meant
+    # Caddy silently fell back to its own Let's Encrypt ACME issuance whenever
+    # this file-bind-mounted container got recreated from a fresh checkout.
+    tls /data/cf-origin/api_cms_origin.crt /data/cf-origin/api_cms_origin.key
+
     # Enable gzip compression
     encode gzip
 

--- a/deployment/docker/docker-compose.production.yml
+++ b/deployment/docker/docker-compose.production.yml
@@ -33,7 +33,10 @@ services:
     environment:
       SITE_DOMAIN: ${SITE_DOMAIN}
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Mount the directory, not the file: git checkout/reset replaces files
+      # with new inodes, which orphans a single-file bind mount from the live
+      # container until it's recreated. A directory mount survives that.
+      - ./:/etc/caddy:ro
       - caddy_data:/data
       - caddy_config:/config
       - static_volume:/srv/static:ro

--- a/deployment/docker/docker-compose.staging.yml
+++ b/deployment/docker/docker-compose.staging.yml
@@ -33,7 +33,10 @@ services:
     environment:
       SITE_DOMAIN: ${SITE_DOMAIN}
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Mount the directory, not the file: git checkout/reset replaces files
+      # with new inodes, which orphans a single-file bind mount from the live
+      # container until it's recreated. A directory mount survives that.
+      - ./:/etc/caddy:ro
       - caddy_data:/data
       - caddy_config:/config
       - static_volume:/srv/static:ro


### PR DESCRIPTION
## Summary
Surfaced while deploying #405 (real-client-IP fix): recreating `docker-caddy-1` to pick up that change revealed its Caddyfile had silently drifted from this repo. A `tls /data/cf-origin/...` directive existed only on the box (manually added when the Cloudflare Origin CA cert was provisioned 2026-07-09), never committed here. Without it, a fresh container falls back to Caddy's own Let's Encrypt/ACME issuance instead of the intended Origin CA cert.

**Root cause**: the Caddyfile was bind-mounted as a single file (`./Caddyfile:/etc/caddy/Caddyfile:ro`). `git reset --hard` (run on every deploy) replaces files with new inodes rather than editing in place, which silently orphans a single-file bind mount from an already-running container -- no error, just stale content -- until that container is recreated. Caddy is never in the deploy pipeline's recreate step (only `web` is), so **every Caddyfile change merged since the cert was added has likely been silently inert on both prod and staging** -- including the throttle IP fix in #405, until I manually force-recreated `docker-caddy-1` to confirm/debug this.

## Changes
- Restore the `tls` directive in `deployment/docker/Caddyfile` (cert files confirmed intact in the persistent `caddy_data` volume at `/data/cf-origin/` on prod, dated 2026-07-09).
- Change both `docker-compose.production.yml` and `docker-compose.staging.yml` to bind-mount the directory (`./:/etc/caddy:ro`) instead of the single file, so this class of drift structurally can't recur.

## Verification already done (prod)
- Force-recreated `docker-caddy-1` earlier while debugging -- confirmed cert files present and dated correctly in `/data/cf-origin/`.
- External health check (`https://api.cms.itqan.dev/health`) returned 200 throughout, including during the container swap.
- Confirmed `X-Forwarded-For` now correctly reflects `Cf-Connecting-Ip` on live traffic post-recreate (the fix from #405 is now actually live).

## Test plan
- [ ] CI passes
- [ ] Deploy to prod, confirm `docker-caddy-1` recreates cleanly with the tls directive present
- [ ] Confirm cert served is still the Cloudflare Origin CA cert (not a fresh ACME one)
- [ ] Apply the same fix to staging's live box if it has the same drift (not verified yet, staging wasn't touched this session)