### PR TITLE
feat(quran): add Surah→Ayah→Word hierarchy tree API

### DIFF
--- a/apps/quran/api/internal/hierarchy.py
+++ b/apps/quran/api/internal/hierarchy.py
@@ -1,0 +1,64 @@
+from typing import Literal
+
+from ninja import Schema
+
+from apps.core.ninja_utils.errors import NinjaErrorResponse
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+from apps.quran.repositories.quran import QuranRepository
+from apps.quran.services.quran import QuranService
+
+router = ItqanRouter(tags=[NinjaTag.QURAN])
+
+
+class HierarchySuraOut(Schema):
+    id: int
+    name: str
+    transliterated_name: str
+    english_name: str
+    ayas_count: int
+    start_offset: int
+
+
+class HierarchyAyahOut(Schema):
+    id: int
+    number_in_sura: int
+    text: str
+    words_count: int
+
+
+class HierarchyWordOut(Schema):
+    id: int
+    position_in_ayah: int
+    text: str
+
+
+@router.get("hierarchy/tree/", response=list[HierarchySuraOut])
+def list_hierarchy_tree(request: Request):
+    """List all 114 suras with summary fields for hierarchy root expansion."""
+    service = QuranService(QuranRepository())
+    return service.list_hierarchy_tree()
+
+
+@router.get(
+    "hierarchy/surah/{int:sura_id}/tree/",
+    response={200: list[HierarchyAyahOut], 404: NinjaErrorResponse[Literal["sura_not_found"]]},
+)
+def list_surah_ayah_tree(request: Request, sura_id: int):
+    """List ayahs of a sura with word counts (no word rows) for lazy tree expand."""
+    service = QuranService(QuranRepository())
+    return service.list_surah_ayah_tree(sura_id)
+
+
+@router.get(
+    "hierarchy/ayah/{int:sura_id}/{int:number_in_sura}/words/",
+    response={
+        200: list[HierarchyWordOut],
+        404: NinjaErrorResponse[Literal["sura_not_found"]] | NinjaErrorResponse[Literal["ayah_not_found"]],
+    },
+)
+def get_ayah_words(request: Request, sura_id: int, number_in_sura: int):
+    """Return ordered words for a single ayah (drill-down leaf)."""
+    service = QuranService(QuranRepository())
+    return service.get_ayah_words(sura_id, number_in_sura)

--- a/apps/quran/api/internal/hierarchy.py
+++ b/apps/quran/api/internal/hierarchy.py
@@ -55,7 +55,7 @@ def list_surah_ayah_tree(request: Request, sura_id: int):
     "hierarchy/ayah/{int:sura_id}/{int:number_in_sura}/words/",
     response={
         200: list[HierarchyWordOut],
-        404: NinjaErrorResponse[Literal["sura_not_found"]] | NinjaErrorResponse[Literal["ayah_not_found"]],
+        404: NinjaErrorResponse[Literal["ayah_not_found"]],
     },
 )
 def get_ayah_words(request: Request, sura_id: int, number_in_sura: int):

--- a/apps/quran/repositories/quran.py
+++ b/apps/quran/repositories/quran.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apps.quran.models import Ayah, Sura
+from django.db.models import Count
+
+from apps.quran.models import Ayah, Sura, Word
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -14,6 +16,7 @@ class QuranRepository:
     def __init__(self) -> None:
         self.sura_model = Sura
         self.ayah_model = Ayah
+        self.word_model = Word
 
     def list_suras(self) -> QuerySet[Sura]:
         return self.sura_model.objects.all()
@@ -36,3 +39,21 @@ class QuranRepository:
             )
         except self.ayah_model.DoesNotExist:
             return None
+
+    def list_hierarchy_tree(self) -> QuerySet[Sura]:
+        return self.sura_model.objects.all().order_by("id")
+
+    def list_surah_ayah_tree(self, sura_id: int) -> QuerySet[Ayah]:
+        return (
+            self.ayah_model.objects.filter(sura_id=sura_id)
+            .annotate(words_count=Count("words"))
+            .order_by("number_in_sura")
+        )
+
+    def ayah_exists(self, sura_id: int, number_in_sura: int) -> bool:
+        return self.ayah_model.objects.filter(sura_id=sura_id, number_in_sura=number_in_sura).exists()
+
+    def get_ayah_words(self, sura_id: int, number_in_sura: int) -> QuerySet[Word]:
+        return self.word_model.objects.filter(sura_id=sura_id, ayah__number_in_sura=number_in_sura).order_by(
+            "position_in_ayah"
+        )

--- a/apps/quran/repositories/quran.py
+++ b/apps/quran/repositories/quran.py
@@ -50,10 +50,9 @@ class QuranRepository:
             .order_by("number_in_sura")
         )
 
-    def ayah_exists(self, sura_id: int, number_in_sura: int) -> bool:
-        return self.ayah_model.objects.filter(sura_id=sura_id, number_in_sura=number_in_sura).exists()
-
-    def get_ayah_words(self, sura_id: int, number_in_sura: int) -> QuerySet[Word]:
+    def get_ayah_words(self, sura_id: int, number_in_sura: int) -> QuerySet[Word] | None:
+        if not self.ayah_model.objects.filter(sura_id=sura_id, number_in_sura=number_in_sura).exists():
+            return None
         return self.word_model.objects.filter(sura_id=sura_id, ayah__number_in_sura=number_in_sura).order_by(
             "position_in_ayah"
         )

--- a/apps/quran/services/quran.py
+++ b/apps/quran/services/quran.py
@@ -57,11 +57,11 @@ class QuranService:
         return self.repo.list_surah_ayah_tree(sura_id)
 
     def get_ayah_words(self, sura_id: int, number_in_sura: int) -> QuerySet[Word]:
-        self.get_sura(sura_id)
-        if not self.repo.ayah_exists(sura_id, number_in_sura):
+        words = self.repo.get_ayah_words(sura_id, number_in_sura)
+        if words is None:
             raise ItqanError(
                 error_name="ayah_not_found",
                 message=_("Ayah does not exist."),
                 status_code=404,
             )
-        return self.repo.get_ayah_words(sura_id, number_in_sura)
+        return words

--- a/apps/quran/services/quran.py
+++ b/apps/quran/services/quran.py
@@ -10,7 +10,7 @@ from apps.quran.repositories.quran import QuranRepository
 if TYPE_CHECKING:
     from django.db.models import QuerySet
 
-    from apps.quran.models import Ayah, Sura
+    from apps.quran.models import Ayah, Sura, Word
 
 
 class QuranService:
@@ -48,3 +48,20 @@ class QuranService:
     def list_ayahs_for_sura(self, sura_id: int) -> QuerySet[Ayah]:
         self.get_sura(sura_id)
         return self.repo.list_ayahs_for_sura(sura_id)
+
+    def list_hierarchy_tree(self) -> QuerySet[Sura]:
+        return self.repo.list_hierarchy_tree()
+
+    def list_surah_ayah_tree(self, sura_id: int) -> QuerySet[Ayah]:
+        self.get_sura(sura_id)
+        return self.repo.list_surah_ayah_tree(sura_id)
+
+    def get_ayah_words(self, sura_id: int, number_in_sura: int) -> QuerySet[Word]:
+        self.get_sura(sura_id)
+        if not self.repo.ayah_exists(sura_id, number_in_sura):
+            raise ItqanError(
+                error_name="ayah_not_found",
+                message=_("Ayah does not exist."),
+                status_code=404,
+            )
+        return self.repo.get_ayah_words(sura_id, number_in_sura)

--- a/apps/quran/tests/internal/test_hierarchy_endpoints.py
+++ b/apps/quran/tests/internal/test_hierarchy_endpoints.py
@@ -1,0 +1,118 @@
+from model_bakery import baker
+
+from apps.core.tests.base import BaseTestCase
+from apps.quran.models import Ayah, Sura, Word
+from apps.users.models import User
+
+
+class HierarchyEndpointsTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.sura = baker.make(
+            Sura,
+            id=1,
+            name="الفاتحة",
+            transliterated_name="Al-Faatiha",
+            english_name="The Opening",
+            ayas_count=2,
+            start_offset=0,
+            revelation_type="Meccan",
+            revelation_order=5,
+            rukus_count=1,
+        )
+        self.ayah1 = baker.make(
+            Ayah, id=1, sura=self.sura, number_in_sura=1, text="بِسۡمِ ٱللَّهِ", juz=1, hizb_quarter=1, page=1
+        )
+        self.ayah2 = baker.make(
+            Ayah, id=2, sura=self.sura, number_in_sura=2, text="ٱلۡحَمۡدُ لِلَّهِ", juz=1, hizb_quarter=1, page=1
+        )
+        baker.make(Word, id=1, sura=self.sura, ayah=self.ayah1, position_in_ayah=1, text="بِسْمِ")
+        baker.make(Word, id=2, sura=self.sura, ayah=self.ayah1, position_in_ayah=2, text="اللَّهِ")
+
+    def test_list_hierarchy_tree_where_authenticated_should_return_sura_summaries(self):
+        # Arrange
+        user = baker.make(User, email="reader@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Act
+        response = self.client.get("/cms-api/hierarchy/tree/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body), 1)
+        self.assertEqual(
+            body[0],
+            {
+                "id": 1,
+                "name": "الفاتحة",
+                "transliterated_name": "Al-Faatiha",
+                "english_name": "The Opening",
+                "ayas_count": 2,
+                "start_offset": 0,
+            },
+        )
+
+    def test_list_surah_ayah_tree_where_exists_should_return_ayahs_with_words_count_only(self):
+        # Arrange
+        user = baker.make(User, email="reader@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Act
+        response = self.client.get("/cms-api/hierarchy/surah/1/tree/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body), 2)
+        self.assertEqual(body[0]["id"], 1)
+        self.assertEqual(body[0]["number_in_sura"], 1)
+        self.assertEqual(body[0]["words_count"], 2)
+        self.assertEqual(body[1]["words_count"], 0)
+        self.assertNotIn("words", body[0])
+        self.assertNotIn("words", body[1])
+
+    def test_list_surah_ayah_tree_where_sura_missing_should_return_404_sura_not_found(self):
+        # Arrange
+        user = baker.make(User, email="reader@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Act
+        response = self.client.get("/cms-api/hierarchy/surah/999/tree/")
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error_name"], "sura_not_found")
+
+    def test_get_ayah_words_where_exists_should_return_ordered_words(self):
+        # Arrange
+        user = baker.make(User, email="reader@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Act
+        response = self.client.get("/cms-api/hierarchy/ayah/1/1/words/")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual([w["text"] for w in body], ["بِسْمِ", "اللَّهِ"])
+        self.assertEqual([w["position_in_ayah"] for w in body], [1, 2])
+
+    def test_get_ayah_words_where_ayah_missing_should_return_404_ayah_not_found(self):
+        # Arrange
+        user = baker.make(User, email="reader@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Act
+        response = self.client.get("/cms-api/hierarchy/ayah/1/99/words/")
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error_name"], "ayah_not_found")
+
+    def test_list_hierarchy_tree_where_unauthenticated_should_return_401(self):
+        # Arrange / Act — cms_api mounts with internal_auth (SessionToken required)
+        response = self.client.get("/cms-api/hierarchy/tree/")
+
+        # Assert
+        self.assertEqual(response.status_code, 401)

--- a/apps/quran/tests/internal/test_hierarchy_endpoints.py
+++ b/apps/quran/tests/internal/test_hierarchy_endpoints.py
@@ -38,7 +38,7 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/tree/")
 
         # Assert
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code, response.content)
         body = response.json()
         self.assertEqual(len(body), 1)
         self.assertEqual(
@@ -62,7 +62,7 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/surah/1/tree/")
 
         # Assert
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code, response.content)
         body = response.json()
         self.assertEqual(len(body), 2)
         self.assertEqual(body[0]["id"], 1)
@@ -81,7 +81,7 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/surah/999/tree/")
 
         # Assert
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(404, response.status_code, response.content)
         self.assertEqual(response.json()["error_name"], "sura_not_found")
 
     def test_get_ayah_words_where_exists_should_return_ordered_words(self):
@@ -93,7 +93,7 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/ayah/1/1/words/")
 
         # Assert
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code, response.content)
         body = response.json()
         self.assertEqual([w["text"] for w in body], ["بِسْمِ", "اللَّهِ"])
         self.assertEqual([w["position_in_ayah"] for w in body], [1, 2])
@@ -107,7 +107,7 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/ayah/1/99/words/")
 
         # Assert
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(404, response.status_code, response.content)
         self.assertEqual(response.json()["error_name"], "ayah_not_found")
 
     def test_list_hierarchy_tree_where_unauthenticated_should_return_401(self):
@@ -115,4 +115,4 @@ class HierarchyEndpointsTest(BaseTestCase):
         response = self.client.get("/cms-api/hierarchy/tree/")
 
         # Assert
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(401, response.status_code, response.content)

--- a/apps/quran/tests/internal/test_hierarchy_workflow.py
+++ b/apps/quran/tests/internal/test_hierarchy_workflow.py
@@ -41,16 +41,16 @@ class HierarchyWorkflowTest(BaseTestCase):
 
         # Step 1: root tree
         tree_res = self.client.get("/cms-api/hierarchy/tree/")
-        self.assertEqual(tree_res.status_code, 200, tree_res.content)
+        self.assertEqual(200, tree_res.status_code, tree_res.content)
         suras = tree_res.json()
-        self.assertGreaterEqual(len(suras), 1)
+        self.assertEqual(1, len(suras))
         sura_id = suras[0]["id"]
         self.assertEqual(suras[0]["ayas_count"], 2)
         self.assertEqual(suras[0]["start_offset"], 0)
 
         # Step 2: expand surah → ayahs with counts, no nested words
         ayah_tree_res = self.client.get(f"/cms-api/hierarchy/surah/{sura_id}/tree/")
-        self.assertEqual(ayah_tree_res.status_code, 200, ayah_tree_res.content)
+        self.assertEqual(200, ayah_tree_res.status_code, ayah_tree_res.content)
         ayahs = ayah_tree_res.json()
         self.assertEqual(len(ayahs), 2)
         for ayah in ayahs:
@@ -62,7 +62,7 @@ class HierarchyWorkflowTest(BaseTestCase):
 
         # Step 3: expand ayah → ordered words; length matches words_count
         words_res = self.client.get(f"/cms-api/hierarchy/ayah/{sura_id}/{ayah_with_words['number_in_sura']}/words/")
-        self.assertEqual(words_res.status_code, 200, words_res.content)
+        self.assertEqual(200, words_res.status_code, words_res.content)
         words = words_res.json()
         self.assertEqual(len(words), ayah_with_words["words_count"])
         self.assertEqual([w["position_in_ayah"] for w in words], [1, 2])
@@ -75,14 +75,14 @@ class HierarchyWorkflowTest(BaseTestCase):
 
         # Step 1-2: successful expands
         tree_res = self.client.get("/cms-api/hierarchy/tree/")
-        self.assertEqual(tree_res.status_code, 200)
+        self.assertEqual(200, tree_res.status_code, tree_res.content)
         sura_id = tree_res.json()[0]["id"]
 
         ayah_tree_res = self.client.get(f"/cms-api/hierarchy/surah/{sura_id}/tree/")
-        self.assertEqual(ayah_tree_res.status_code, 200)
+        self.assertEqual(200, ayah_tree_res.status_code, ayah_tree_res.content)
         self.assertEqual(len(ayah_tree_res.json()), 2)
 
         # Step 3: missing ayah after a valid expand
         words_res = self.client.get(f"/cms-api/hierarchy/ayah/{sura_id}/99/words/")
-        self.assertEqual(words_res.status_code, 404)
+        self.assertEqual(404, words_res.status_code, words_res.content)
         self.assertEqual(words_res.json()["error_name"], "ayah_not_found")

--- a/apps/quran/tests/internal/test_hierarchy_workflow.py
+++ b/apps/quran/tests/internal/test_hierarchy_workflow.py
@@ -1,0 +1,88 @@
+from model_bakery import baker
+
+from apps.core.tests.base import BaseTestCase
+from apps.quran.models import Ayah, Sura, Word
+from apps.users.models import User
+
+
+class HierarchyWorkflowTest(BaseTestCase):
+    """
+    End-to-end drill-down: hierarchy tree → surah ayah tree → ayah words.
+    Mirrors the lazy-load path the CMS frontend hierarchy manager will use.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sura = baker.make(
+            Sura,
+            id=1,
+            name="الفاتحة",
+            transliterated_name="Al-Faatiha",
+            english_name="The Opening",
+            ayas_count=2,
+            start_offset=0,
+            revelation_type="Meccan",
+            revelation_order=5,
+            rukus_count=1,
+        )
+        self.ayah1 = baker.make(
+            Ayah, id=1, sura=self.sura, number_in_sura=1, text="بِسۡمِ ٱللَّهِ", juz=1, hizb_quarter=1, page=1
+        )
+        baker.make(
+            Ayah, id=2, sura=self.sura, number_in_sura=2, text="ٱلۡحَمۡدُ لِلَّهِ", juz=1, hizb_quarter=1, page=1
+        )
+        baker.make(Word, id=1, sura=self.sura, ayah=self.ayah1, position_in_ayah=1, text="بِسْمِ")
+        baker.make(Word, id=2, sura=self.sura, ayah=self.ayah1, position_in_ayah=2, text="اللَّهِ")
+
+    def test_hierarchy_drill_down_workflow_where_data_exists_should_lazy_load_words(self):
+        # Arrange
+        user = baker.make(User, email="workflow@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Step 1: root tree
+        tree_res = self.client.get("/cms-api/hierarchy/tree/")
+        self.assertEqual(tree_res.status_code, 200, tree_res.content)
+        suras = tree_res.json()
+        self.assertGreaterEqual(len(suras), 1)
+        sura_id = suras[0]["id"]
+        self.assertEqual(suras[0]["ayas_count"], 2)
+        self.assertEqual(suras[0]["start_offset"], 0)
+
+        # Step 2: expand surah → ayahs with counts, no nested words
+        ayah_tree_res = self.client.get(f"/cms-api/hierarchy/surah/{sura_id}/tree/")
+        self.assertEqual(ayah_tree_res.status_code, 200, ayah_tree_res.content)
+        ayahs = ayah_tree_res.json()
+        self.assertEqual(len(ayahs), 2)
+        for ayah in ayahs:
+            self.assertNotIn("words", ayah)
+            self.assertIn("words_count", ayah)
+
+        ayah_with_words = next(a for a in ayahs if a["words_count"] > 0)
+        self.assertEqual(ayah_with_words["words_count"], 2)
+
+        # Step 3: expand ayah → ordered words; length matches words_count
+        words_res = self.client.get(f"/cms-api/hierarchy/ayah/{sura_id}/{ayah_with_words['number_in_sura']}/words/")
+        self.assertEqual(words_res.status_code, 200, words_res.content)
+        words = words_res.json()
+        self.assertEqual(len(words), ayah_with_words["words_count"])
+        self.assertEqual([w["position_in_ayah"] for w in words], [1, 2])
+        self.assertEqual([w["text"] for w in words], ["بِسْمِ", "اللَّهِ"])
+
+    def test_hierarchy_drill_down_workflow_where_ayah_missing_should_return_ayah_not_found(self):
+        # Arrange
+        user = baker.make(User, email="workflow@example.com", is_active=True)
+        self.authenticate_user(user)
+
+        # Step 1–2: successful expands
+        tree_res = self.client.get("/cms-api/hierarchy/tree/")
+        self.assertEqual(tree_res.status_code, 200)
+        sura_id = tree_res.json()[0]["id"]
+
+        ayah_tree_res = self.client.get(f"/cms-api/hierarchy/surah/{sura_id}/tree/")
+        self.assertEqual(ayah_tree_res.status_code, 200)
+        self.assertEqual(len(ayah_tree_res.json()), 2)
+
+        # Step 3: missing ayah after a valid expand
+        words_res = self.client.get(f"/cms-api/hierarchy/ayah/{sura_id}/99/words/")
+        self.assertEqual(words_res.status_code, 404)
+        self.assertEqual(words_res.json()["error_name"], "ayah_not_found")

--- a/apps/quran/tests/internal/test_hierarchy_workflow.py
+++ b/apps/quran/tests/internal/test_hierarchy_workflow.py
@@ -73,7 +73,7 @@ class HierarchyWorkflowTest(BaseTestCase):
         user = baker.make(User, email="workflow@example.com", is_active=True)
         self.authenticate_user(user)
 
-        # Step 1–2: successful expands
+        # Step 1-2: successful expands
         tree_res = self.client.get("/cms-api/hierarchy/tree/")
         self.assertEqual(tree_res.status_code, 200)
         sura_id = tree_res.json()[0]["id"]


### PR DESCRIPTION
## Summary
- Adds lazy CMS hierarchy endpoints: `/cms-api/hierarchy/tree/`, `/surah/{id}/tree/`, `/ayah/{sura}/{n}/words/`
- Lean payloads (word counts on ayah expand; words only on drill-down) so the frontend tree does not over-fetch ~77k words
- Unit + end-to-end drill-down tests for happy path and `ayah_not_found`

Related: https://github.com/Itqan-community/cms-backend/issues/435
Related frontend: https://github.com/Itqan-community/cms-frontend/issues/214

## Test plan
- [x] `pre-commit` on touched files
- [x] `pytest apps/quran/tests/internal/`
- [x] Full pytest suite
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated Quran hierarchy endpoints for browsing suras, ayahs, and ayah words.
  * Sura listings include ayah counts, while ayah listings include word counts.
  * Words can be retrieved in their correct order for a selected ayah.
  * Added clear not-found responses for missing suras or ayahs.

* **Bug Fixes**
  * Unauthenticated hierarchy requests now return an appropriate access error.

* **Tests**
  * Added coverage for hierarchy navigation, ordering, counts, authentication, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->