### PR TITLE
fix: refine logging format and update static markup nosec flag

### DIFF
--- a/apps/content/admin.py
+++ b/apps/content/admin.py
@@ -383,13 +383,11 @@ class AssetAdmin(admin.ModelAdmin):
                 {"error_name": e.error_name, "message": e.message, "extra": e.extra}, status=e.status_code
             )
         except Exception:
-            logger.exception(
-                f"uploads_sign_part_view failed (\
+            logger.exception(f"uploads_sign_part_view failed (\
                     key={(locals().get('body') or {}).get('key')},\
                     upload_id={(locals().get('body') or {}).get('uploadId')},\
                     part_number={(locals().get('body') or {}).get('partNumber')}\
-                )"
-            )
+                )")
             return JsonResponse(
                 {"error_name": "server_error", "message": str(_("An unexpected error occurred"))},
                 status=500,
@@ -418,12 +416,10 @@ class AssetAdmin(admin.ModelAdmin):
                 {"error_name": e.error_name, "message": e.message, "extra": e.extra}, status=e.status_code
             )
         except Exception:
-            logger.exception(
-                f"uploads_finish_view failed (\
+            logger.exception(f"uploads_finish_view failed (\
                     key={(locals().get('body') or {}).get('key')},\
                     upload_id={(locals().get('body') or {}).get('uploadId')}\
-                )"
-            )
+                )")
             return JsonResponse(
                 {"error_name": "server_error", "message": str(_("An unexpected error occurred"))},
                 status=500,
@@ -444,12 +440,10 @@ class AssetAdmin(admin.ModelAdmin):
                 {"error_name": e.error_name, "message": e.message, "extra": e.extra}, status=e.status_code
             )
         except Exception:
-            logger.exception(
-                f"uploads_abort_view failed (\
+            logger.exception(f"uploads_abort_view failed (\
                     key={(locals().get('body') or {}).get('key')},\
                     upload_id={(locals().get('body') or {}).get('uploadId')}\
-                )"
-            )
+                )")
             return JsonResponse(
                 {"error_name": "server_error", "message": str(_("An unexpected error occurred"))},
                 status=500,

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -114,7 +114,7 @@ class UserAdmin(auth_admin.UserAdmin):
 # Deliberately NOT wrapped in gettext: both languages must appear at once, whereas gettext
 # would resolve to whichever one is active. The Arabic half carries dir="rtl" so it renders
 # correctly even while the admin is in English.
-PERMISSION_HIERARCHY_HELP_TEXT = mark_safe(  # noqa: S308 - static author-controlled markup
+PERMISSION_HIERARCHY_HELP_TEXT = mark_safe(  # nosec B308 - static, hardcoded markup; no request/user input to sanitize.
     "<span>"
     "Permissions are expanded automatically when you save, so you only need to pick the "
     "strongest one for each resource. Within a resource: <strong>Create</strong> and "

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -579,7 +579,6 @@ PERMISSIONS_SETTINGS = {
     "PERMISSIONS": PermissionChoice.choices,
     "MONKEYPATCH_USER": True,
     "OVERRIDE_GROUP_ADMIN": False,
-
 }
 
 NINJA_KEYS_API_KEY_MODEL = "users.APIKey"


### PR DESCRIPTION
- Removed unnecessary line break from config settings.
- Updated `PERMISSION_HIERARCHY_HELP_TEXT` comment to clarify `nosec` reason.
- Simplified multiline logger exception formatting for upload views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal error logging for multipart upload administration actions without changing error handling or responses.

* **Chores**
  * Updated security-scan suppression metadata.
  * Applied minor formatting cleanup to permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->