### PR TITLE
fix(users): prevent data loss on partial developer profile updates

### DIFF
--- a/apps/users/api/internal/profile.py
+++ b/apps/users/api/internal/profile.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from ninja import Schema
 from pydantic import AwareDatetime
 
@@ -79,9 +80,11 @@ def get_user_profile(request: Request):
 
 
 class UserUpdateSchema(Schema):
-    bio: str = ""
-    project_summary: str = ""
-    project_url: str = ""
+    name: str | None = None
+    bio: str | None = None
+    project_summary: str | None = None
+    project_url: str | None = None
+    job_title: str | None = None
 
 
 @router.put(
@@ -93,17 +96,18 @@ class UserUpdateSchema(Schema):
 def update_user_profile(request: Request, profile_data: UserUpdateSchema):
     """Update authenticated user's profile"""
     user = request.user
-    user_developer_profile, _ = Developer.objects.get_or_create(user=user)
+    update_fields = profile_data.model_dump(exclude_unset=True)
 
-    # Update allowed fields
-    if profile_data.bio is not None:
-        user_developer_profile.bio = profile_data.bio
-    if profile_data.project_summary is not None:
-        user_developer_profile.project_summary = profile_data.project_summary
-    if profile_data.project_url is not None:
-        user_developer_profile.project_url = profile_data.project_url
+    with transaction.atomic():
+        if "name" in update_fields:
+            user.name = (update_fields.pop("name") or "").strip()
+            user.save(update_fields=["name"])
 
-    user_developer_profile.save()
+        user_developer_profile, _ = Developer.objects.get_or_create(user=user)
+        for field, value in update_fields.items():
+            if hasattr(user_developer_profile, field):
+                setattr(user_developer_profile, field, (value or "").strip())
+        user_developer_profile.save()
 
     return {
         "id": str(user.id),

--- a/apps/users/tests/test_auth_endpoints.py
+++ b/apps/users/tests/test_auth_endpoints.py
@@ -1,7 +1,7 @@
 from django.utils.crypto import get_random_string
 
 from apps.core.tests.base import BaseTestCase
-from apps.users.models import User
+from apps.users.models import Developer, User
 
 
 class AuthEndpointsTestCase(BaseTestCase):
@@ -106,9 +106,18 @@ class UserProfileTestCase(BaseTestCase):
     def test_update_profile_where_partial_data_should_return_200_with_partial_update(
         self,
     ):
-        """Test partial profile update with only some fields"""
+        """Test partial profile update with only some fields preserves all existing profile fields"""
         # Arrange
         self.authenticate_user(user=self.user)
+        self.user.name = "Initial Name"
+        self.user.save(update_fields=["name"])
+
+        dev, _ = Developer.objects.get_or_create(user=self.user)
+        dev.bio = "Initial Bio"
+        dev.project_summary = "Existing Summary"
+        dev.project_url = "https://example.com"
+        dev.job_title = "Backend Engineer"
+        dev.save()
 
         data = {"bio": "Only bio updated"}
 
@@ -121,9 +130,40 @@ class UserProfileTestCase(BaseTestCase):
 
         # Check updated data
         self.assertEqual(data["bio"], response_data["bio"])
-        # Other fields should remain unchanged
-        self.assertEqual("", response_data["project_summary"])
-        self.assertEqual("", response_data["project_url"])
+        # All other fields should remain unchanged and preserved
+        self.assertEqual("Initial Name", response_data["name"])
+        self.assertEqual("Existing Summary", response_data["project_summary"])
+        self.assertEqual("https://example.com", response_data["project_url"])
+        self.assertEqual("Backend Engineer", response_data["job_title"])
+
+        # Verify DB preservation
+        self.user.refresh_from_db()
+        self.user.developer_profile.refresh_from_db()
+        self.assertEqual("Initial Name", self.user.name)
+        self.assertEqual("Existing Summary", self.user.developer_profile.project_summary)
+        self.assertEqual("https://example.com", self.user.developer_profile.project_url)
+        self.assertEqual("Backend Engineer", self.user.developer_profile.job_title)
+
+    def test_update_profile_where_explicit_null_clears_field(self):
+        """Test sending explicit JSON null clears the corresponding field to empty string"""
+        # Arrange
+        self.authenticate_user(user=self.user)
+        dev, _ = Developer.objects.get_or_create(user=self.user)
+        dev.job_title = "Lead Architect"
+        dev.save()
+
+        data = {"job_title": None}
+
+        # Act
+        response = self.client.put("/cms-api/auth/profile/", data=data, format="json")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        response_data = response.json()
+        self.assertEqual("", response_data["job_title"])
+
+        self.user.developer_profile.refresh_from_db()
+        self.assertEqual("", self.user.developer_profile.job_title)
 
     def test_update_profile_where_unauthenticated_should_return_401(self):
         """Test profile update without authentication returns error"""


### PR DESCRIPTION
This PR resolves a **silent data loss vulnerability** in the profile update API endpoint (`PUT /cms-api/auth/profile/`).

### Root Cause


Previously, `UserUpdateSchema` defined default values for omitted fields as empty strings (`bio=""`, `project_summary=""`, `project_url=""`). When a client submitted a partial update (for example, updating only `bio`), Pydantic populated missing fields with empty strings. The endpoint handler checked `if field is not None:`, evaluating `"" != None` as `True`, which silently erased existing database fields (`project_summary`, `project_url`) and revoked the user's `profile_completed` status (`True` $\rightarrow$ `False`).

---
## Key Remediations
1. **Schema Refactoring (`UserUpdateSchema`)**:
   - Changed schema field default values to `None` (`bio: str | None = None`, etc.).
   - Added support for updating `name` (on `User` model) and `job_title` (on `Developer` model).
2. **Endpoint Handler Refactoring (`update_user_profile`)**:
   - Uses `profile_data.model_dump(exclude_unset=True)` so only fields **explicitly provided in the payload** are mutated.
   - Wrapped profile creation and updates inside `transaction.atomic()` for concurrency and thread safety.
3. **Test Suite Improvements (`test_auth_endpoints.py`)**:
   - Updated `test_update_profile_where_partial_data_should_return_200_with_partial_update` to set pre-existing data and verify that partial updates preserve all unsent profile fields in both the response and database.
---
## Verification & Testing
- **Unit Tests**: Executed `pytest apps/users/tests/test_auth_endpoints.py` (10/10 tests passed).
- **Empirical Execution**: Validated using Django shell before and after the fix to verify that pre-existing profile
```Python
from apps.users.models import User, Developer
from apps.users.api.internal.profile import UserUpdateSchema, update_user_profile

# 1. Create a developer user with complete profile data
user, _ = User.objects.get_or_create(email='test_audit_dev@example.com')
dev, _ = Developer.objects.get_or_create(user=user)
dev.bio = 'Original Bio'
dev.project_summary = 'Original Important Project Summary'
dev.project_url = 'https://example.com/my-project'
dev.job_title = 'Lead Architect'
dev.save()

print('=== BEFORE PUT ===')
print(f'bio:             {dev.bio!r}')
print(f'project_summary: {dev.project_summary!r}')
print(f'project_url:     {dev.project_url!r}')
print(f'job_title:       {dev.job_title!r}')
print(f'completed:       {dev.profile_completed}')

# 2. Simulate API request payload containing ONLY 'bio'
class MockRequest:
    def __init__(self, user):
        self.user = user

payload = {'bio': 'Updated Bio Only'}
schema_input = UserUpdateSchema(**payload)

# 3. Call the actual API endpoint handler function
update_user_profile(MockRequest(user), schema_input)

# 4. Check the updated state in the database
dev.refresh_from_db()
print('\n=== AFTER PUT (Sending ONLY {"bio": "Updated Bio Only"}) ===')
print(f'bio:             {dev.bio!r}')
print(f'project_summary: {dev.project_summary!r}  <-- DATA ERASED!')
print(f'project_url:     {dev.project_url!r}  <-- DATA ERASED!')
print(f'job_title:       {dev.job_title!r}')
print(f'completed:       {dev.profile_completed}  <-- STATUS REVOKED!')

# Cleanup test record
user.delete()

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating profile names and job titles.
  * Profile updates can modify only the fields provided, preserving omitted information.
  * Supported profile fields can be explicitly cleared when needed.

* **Bug Fixes**
  * Existing profile information, including project summaries and URLs, is preserved during partial updates.
  * Cleared fields now consistently update both the displayed profile and saved data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->