### PR TITLE
fix(core): prevent race condition and data leak in throttle logging

### DIFF
--- a/apps/content/tests/public/test_throttling.py
+++ b/apps/content/tests/public/test_throttling.py
@@ -210,3 +210,58 @@ class ThrottleLoggingTest(BaseTestCase):
         # Assert
         self.assertEqual("public_user", context["throttle_scope"])
         self.assertNotIn("is_authenticated", context)
+
+    def test_throttle_logging_concurrent_requests_isolation(self):
+        import threading
+
+        cache.clear()
+        user_alice = User.objects.create_user(email="alice@test.com", name="Alice")
+        user_bob = User.objects.create_user(email="bob@test.com", name="Bob")
+
+        throttle = PublicApiUserRateThrottle()
+        throttle.num_requests = 1
+        throttle.duration = 60
+
+        req_alice = _make_request(user=user_alice, remote_addr="10.0.0.1")
+        req_bob = _make_request(user=user_bob, remote_addr="10.0.0.2")
+
+        # Exhaust Alice's budget so next call will fail
+        throttle.allow_request(req_alice)
+
+        alice_cached_event = threading.Event()
+        bob_cached_event = threading.Event()
+        alice_logs = []
+
+        def run_alice():
+            # 1. Alice evaluates cache key
+            throttle.get_cache_key(req_alice)
+            # 2. Signal that Alice has cached her request context
+            alice_cached_event.set()
+            # 3. Wait until Bob has definitely called get_cache_key on the shared singleton
+            self.assertTrue(bob_cached_event.wait(timeout=2.0))
+            # 4. Now Alice triggers throttle failure
+            with self.assertLogs("apps.core.ninja_utils.throttle", level="ERROR") as logs:
+                throttle.throttle_failure()
+                alice_logs.extend(logs.records)
+
+        def run_bob():
+            # 1. Wait for Alice to cache her context first
+            self.assertTrue(alice_cached_event.wait(timeout=2.0))
+            # 2. Bob evaluates cache key concurrently on the shared singleton
+            throttle.get_cache_key(req_bob)
+            # 3. Signal to Alice that Bob has finished storing his context
+            bob_cached_event.set()
+
+        t1 = threading.Thread(target=run_alice)
+        t2 = threading.Thread(target=run_bob)
+
+        # Act
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Assert: Alice's log must contain Alice's email, not Bob's
+        self.assertTrue(len(alice_logs) > 0)
+        self.assertEqual("alice@test.com", alice_logs[0].user_email)
+        self.assertEqual("10.0.0.1", alice_logs[0].remote_addr)

--- a/apps/core/ninja_utils/throttle.py
+++ b/apps/core/ninja_utils/throttle.py
@@ -1,3 +1,4 @@
+import contextvars
 import logging
 from typing import Any
 
@@ -7,6 +8,10 @@ from ninja.throttling import AnonRateThrottle as NinjaAnonRateThrottle, UserRate
 from rest_framework.throttling import UserRateThrottle as DRFUserRateThrottle
 
 logger = logging.getLogger(__name__)
+
+_throttle_request_ctx: contextvars.ContextVar[HttpRequest | None] = contextvars.ContextVar(
+    "throttle_request_ctx", default=None
+)
 
 
 def build_throttle_log_context(
@@ -88,8 +93,8 @@ class _LoggingThrottleMixin:
     """
     Emits a structured error log with all the user/client data we have whenever
     a request is throttled. Relies on the throttle's ``get_cache_key`` having
-    stashed the request on ``self._request`` (the only throttle hook that
-    receives the request), so ``throttle_failure`` can read it back.
+    stashed the request in thread/async-isolated context storage (``_throttle_request_ctx``),
+    so ``throttle_failure`` can read it back safely without mutating singleton state.
     """
 
     scope: str
@@ -98,7 +103,7 @@ class _LoggingThrottleMixin:
 
     def throttle_failure(self) -> bool:
         context = build_throttle_log_context(
-            getattr(self, "_request", None),
+            _throttle_request_ctx.get(),
             scope=self.scope,
             rate=self.rate,
             key=getattr(self, "key", None),
@@ -129,7 +134,7 @@ class PublicApiUserRateThrottle(_LoggingThrottleMixin, NinjaUserRateThrottle):
         return settings.PUBLIC_API_USER_THROTTLE_RATE
 
     def get_cache_key(self, request: HttpRequest) -> str | None:
-        self._request = request
+        _throttle_request_ctx.set(request)
         # Only throttle authenticated clients here; anonymous traffic is
         # covered by PublicApiAnonRateThrottle so the two never share a bucket.
         if not (request.user and request.user.is_authenticated):
@@ -163,7 +168,7 @@ class PublicApiAnonRateThrottle(_LoggingThrottleMixin, NinjaAnonRateThrottle):
         return settings.PUBLIC_API_ANON_THROTTLE_RATE
 
     def get_cache_key(self, request: HttpRequest) -> str | None:
-        self._request = request
+        _throttle_request_ctx.set(request)
         if request.user and request.user.is_authenticated:
             return None  # Authenticated clients are handled by the user throttle.
 


### PR DESCRIPTION
### Problem
The public API rate throttles (`PublicApiUserRateThrottle`, `PublicApiAnonRateThrottle`) are instantiated as module-level singletons in `config/developers_api.py`. In `apps/core/ninja_utils/throttle.py`, `get_cache_key` stored `self._request = request` directly on the singleton instance so `throttle_failure()` could read it during logging.
Under concurrent requests in multi-threaded/ASGI environments (such as Gunicorn with Uvicorn workers running sync Ninja endpoints in a thread pool), thread B could overwrite `self._request` while thread A was checking rate limits in Redis. When thread A exceeded its budget, `throttle_failure()` logged thread B's user ID, email, IP, and OAuth credentials.
### Solution
- Replaced `self._request` instance mutation with a thread-isolated / async-safe `contextvars.ContextVar` (`_throttle_request_ctx`).
- Updated `_LoggingThrottleMixin.throttle_failure` to read from the context variable.
- Added a concurrent multi-threaded regression test `test_throttle_logging_concurrent_requests_isolation` in `apps/content/tests/public/test_throttling.py`.
### Verification
Run script
```Python
"""
Simulation script demonstrating the concurrency race condition in throttle logging
before and after the contextvars fix.

Scenario:
- A shared singleton throttle instance is used by the application.
- Alice (User A) makes a request that exceeds rate limit budget.
- Concurrently, Bob (User B) makes a request.
- We observe whose context is captured when Alice's throttle failure is logged.
"""

import os
import sys
import time
import threading
from unittest.mock import MagicMock

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
import django
django.setup()

from django.http import HttpRequest
from apps.core.ninja_utils.throttle import (
    PublicApiUserRateThrottle,
    build_throttle_log_context,
    _throttle_request_ctx,
)


def create_mock_user(user_id: int, email: str, name: str):
    user = MagicMock()
    user.pk = user_id
    user.email = email
    user.name = name
    user.is_authenticated = True
    user.is_staff = False
    return user


def create_mock_request(user, ip: str):
    request = HttpRequest()
    request.user = user
    request.META["REMOTE_ADDR"] = ip
    request.path = "/api/v1/reciters/"
    request.method = "GET"
    return request


# -----------------------------------------------------------------------------
# 1. SIMULATION OF "BEFORE" (Buggy Singleton Mutation)
# -----------------------------------------------------------------------------
class BuggyThrottle:
    """Old implementation that mutated self._request on the shared singleton."""
    scope = "public_user"
    rate = "10/min"
    key = "throttle_key_alice"

    def get_cache_key(self, request: HttpRequest) -> str:
        # BUG: Storing on self (shared across all threads)
        self._request = request
        return f"public_user:{request.user.pk}"

    def throttle_failure(self) -> dict:
        # Reads from self._request
        return build_throttle_log_context(
            getattr(self, "_request", None),
            scope=self.scope,
            rate=self.rate,
            key=self.key,
        )


def run_simulation_before():
    print("\n" + "=" * 60)
    print("DEMO 1: BEFORE FIX (Mutating `self._request` on Singleton)")
    print("=" * 60)

    shared_buggy_throttle = BuggyThrottle()

    user_alice = create_mock_user(101, "alice@tenant-a.com", "Alice")
    req_alice = create_mock_request(user_alice, "192.168.1.10")

    user_bob = create_mock_user(202, "bob@tenant-b.com", "Bob")
    req_bob = create_mock_request(user_bob, "10.0.0.50")

    alice_logged_context = {}
    barrier = threading.Barrier(2)

    def thread_alice():
        # Step 1: Alice sets self._request
        shared_buggy_throttle.get_cache_key(req_alice)
        # Alice is delayed checking Redis / waiting for network
        barrier.wait()  # synchronize with Bob
        time.sleep(0.05)
        # Alice experiences throttle failure and logs
        nonlocal alice_logged_context
        alice_logged_context = shared_buggy_throttle.throttle_failure()

    def thread_bob():
        barrier.wait()  # synchronize with Alice
        # Bob executes get_cache_key right while Alice is waiting
        shared_buggy_throttle.get_cache_key(req_bob)

    t1 = threading.Thread(target=thread_alice, name="Thread-Alice")
    t2 = threading.Thread(target=thread_bob, name="Thread-Bob")

    t1.start()
    t2.start()
    t1.join()
    t2.join()

    print(f"Expected Alice's log to contain: user_id=101 (alice@tenant-a.com, IP=192.168.1.10)")
    print(f"ACTUAL Logged Context for Alice's throttle failure:")
    print(f"  - user_id    : {alice_logged_context.get('user_id')}")
    print(f"  - user_email : {alice_logged_context.get('user_email')}")
    print(f"  - remote_addr: {alice_logged_context.get('remote_addr')}")

    if alice_logged_context.get("user_email") == "bob@tenant-b.com":
        print("\n❌ DATA LEAK CONFIRMED: Alice's throttle log leaked Bob's sensitive tenant data!")
    else:
        print("\nNote: Thread execution order did not collide.")


# -----------------------------------------------------------------------------
# 2. SIMULATION OF "AFTER" (Fixed with contextvars)
# -----------------------------------------------------------------------------
def run_simulation_after():
    print("\n" + "=" * 60)
    print("DEMO 2: AFTER FIX (Using `contextvars` for Request Context)")
    print("=" * 60)

    # Actual fixed PublicApiUserRateThrottle instance
    shared_fixed_throttle = PublicApiUserRateThrottle()
    shared_fixed_throttle.key = "throttle_key_alice"

    user_alice = create_mock_user(101, "alice@tenant-a.com", "Alice")
    req_alice = create_mock_request(user_alice, "192.168.1.10")

    user_bob = create_mock_user(202, "bob@tenant-b.com", "Bob")
    req_bob = create_mock_request(user_bob, "10.0.0.50")

    alice_logged_context = {}
    barrier = threading.Barrier(2)

    def thread_alice():
        # Step 1: Alice sets contextvar in her thread context
        shared_fixed_throttle.get_cache_key(req_alice)
        # Alice is delayed checking Redis / waiting for network
        barrier.wait()
        time.sleep(0.05)
        # Alice experiences throttle failure and logs
        nonlocal alice_logged_context
        alice_logged_context = build_throttle_log_context(
            _throttle_request_ctx.get(),
            scope=shared_fixed_throttle.scope,
            rate=shared_fixed_throttle.rate,
            key=shared_fixed_throttle.key,
        )

    def thread_bob():
        barrier.wait()
        # Bob executes get_cache_key in his thread context
        shared_fixed_throttle.get_cache_key(req_bob)

    t1 = threading.Thread(target=thread_alice, name="Thread-Alice")
    t2 = threading.Thread(target=thread_bob, name="Thread-Bob")

    t1.start()
    t2.start()
    t1.join()
    t2.join()

    print(f"Expected Alice's log to contain: user_id=101 (alice@tenant-a.com, IP=192.168.1.10)")
    print(f"ACTUAL Logged Context for Alice's throttle failure:")
    print(f"  - user_id    : {alice_logged_context.get('user_id')}")
    print(f"  - user_email : {alice_logged_context.get('user_email')}")
    print(f"  - remote_addr: {alice_logged_context.get('remote_addr')}")

    if alice_logged_context.get("user_email") == "alice@tenant-a.com":
        print("\n✅ ISOLATION VERIFIED: Alice's log accurately captured Alice's data without interference from Bob!")
    else:
        print("\n❌ FAILED: Unexpected data in context.")
    print("=" * 60 + "\n")


if __name__ == "__main__":
    run_simulation_before()
    run_simulation_after()

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit rejection logging to consistently show the correct request details during concurrent API activity.
  * Prevented request context from being mixed between simultaneous requests.
* **Tests**
  * Added regression coverage for concurrent throttling scenarios, including user and network address details in rejection logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->