### PR TITLE
feat/authentication non secret reframe

### DIFF
--- a/apps/users/api/internal/api_keys.py
+++ b/apps/users/api/internal/api_keys.py
@@ -48,7 +48,9 @@ if settings.ENABLE_API_KEY_AUTH:
             | NinjaErrorResponse[Literal["api_key_name_taken"]],
         },
         summary="Create API Key",
-        description="Create a new API key. The raw key is returned once and cannot be retrieved again.",
+        description="Create a new API key. This key is a public application identifier, not a "
+        "secret, it is safe to embed in frontend or mobile client code. The key can be "
+        "re-viewed later from the dashboard.",
     )
     def create_api_key(request: Request, data: ApiKeyCreateInSchema):
         api_key, raw_key = _service.create(request.user, data.name, expiry_date=data.expiry_date)

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -384,6 +384,64 @@ retained indefinitely.
 See [ROADMAP.md — §1](./ROADMAP.md#1-appuser-scoped-authentication-self-identification-model)
 for the full problem statement and open questions.
 
+## API Keys: Public Identifiers, Not Secrets
+
+> **Note:** this section applies only to the `X-API-Key` identifier, not the OAuth2
+> `client_secret` described above. The OAuth2 `client_secret` remains a true secret and
+> must stay server-side per the guidance in **Security Best Practices**.
+
+API keys issued by Itqan (`X-API-Key`) are **public application identifiers, not secrets**.
+They are designed to be embedded directly in frontend and mobile client code. Unlike a
+traditional API secret, an Itqan API key does not need to be protected from exposure by
+the developer using it, that exposure is expected and is not a security incident.
+
+### Threat model
+
+An Itqan API key identifies *which application* is calling the API. It does **not** grant
+privileged access, and it is not a bearer credential in the traditional sense:
+
+- A leaked key allows the app to be identified and attributed, nothing more.
+- A leaked key does **not** grant access to another developer's data, another app's
+  identity, or any administrative capability.
+- Abuse from a leaked or misused key is handled through **revocation and rate limiting**
+  (with spoofing accepted as a known limitation in this Phase 1), not through treating
+  the key as a confidential secret.
+
+If a key is exposed in a public client bundle, no rotation is required as a security
+response, though a developer may still choose to rotate it simply to obtain a new
+identifier.
+
+### Rotation and revocation
+
+- **Rotation** is reframed: a developer rotates a key to get a *new identifier*, not
+  because the old one "leaked." Rotation is a routine action, not an incident response.
+- **Revocation** is unchanged and remains the primary abuse-control mechanism, it lets a
+  developer (or Itqan) disable a specific app identity independent of whether the key was
+  ever exposed.
+
+### Storage
+
+Because the key is non-secret to its intended developer audience, developers can view and
+copy it from the dashboard at any time. There is no reveal-once restriction, and no
+"click to reveal" gating — hiding the key by default would imply a secrecy requirement
+that no longer applies.
+
+This "view/copy anytime" behavior is only possible because of a storage change. Two
+different threats are relevant here, and they are not the same thing:
+
+1. A developer exposing *their own* key in a public client bundle, accepted, non-incident.
+2. A breach of Itqan's own database, a single incident that could expose *every* app's
+   key at once if keys were stored in plaintext.
+
+The previous hash-only storage (irreversible by design) cannot support "view anytime" at
+all, a one-way hash cannot be turned back into the original key. To enable re-viewability
+while still protecting against (2), the raw key is stored **encrypted at rest**
+(AES-256-GCM), with the encryption key managed separately from the database (e.g. via a
+KMS or Django's secret management), rather than hashed irreversibly, and rather than
+stored in plaintext. This is a deliberate departure from the hashed-at-rest default,
+acceptable specifically because the key does not grant privileged access.
+
+
 ---
 
 ## Token Lifecycle


### PR DESCRIPTION
## Decision: Store API keys encrypted, not hashed

**Context:** The self-identifying-auth epic reframes API keys as non-secret public
identifiers. This requires keys to be re-viewable in the dashboard, which the current
hash-only storage (`sha512`, one-way) cannot support.

**Decision:** Store the raw key encrypted at rest (AES-256-GCM) instead of hashed,
with the encryption key held separately from the database.

**Why not keep hashing?** Hashing is one-way by design; there is no mechanism to recover
the original key for re-display, regardless of the key's secrecy classification.

**Why not store in plaintext?** "Non-secret" describes the threat model for a key
exposed by *its own developer* in a client bundle; that's accepted. It says nothing about
a breach of Itqan's own database, which would expose every stored key at once if they were
plaintext. Encryption at rest limits that blast radius without preventing legitimate
re-display to the key's owner.

**Trade-off:** This is a deliberate departure from the hashed-at-rest default. It's
acceptable here specifically because the key does not grant privileged access; it only
identifies an app, so encrypted (rather than hashed) storage matches the actual risk.

**Screen Shots:**
<img width="1465" height="735" alt="image" src="https://github.com/user-attachments/assets/e29dade3-2442-431d-9af4-0a6b8228c914" />

Fixes #407 