### PR TITLE
feat(usage-tracking): track API key prefix as application identity

### DIFF
--- a/apps/content/tests/public/test_usage_tracking_integration.py
+++ b/apps/content/tests/public/test_usage_tracking_integration.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.test import override_settings
 from model_bakery import baker
 from oauth2_provider.models import Application
 
@@ -16,7 +17,7 @@ from apps.usage_tracking.decorators.track_usage import (
     _resolve_reciter_name,
     _resolve_reciter_names,
 )
-from apps.users.models import User
+from apps.users.models import APIKey, User
 
 _REDIS = "apps.usage_tracking.decorators.track_usage._get_tracking_redis"
 
@@ -162,6 +163,61 @@ class UsageTrackingIntegrationTest(BaseTestCase):
         # reciter_id additionally resolves a human-readable name for Mixpanel.
         self.assertEqual(self.reciter.name, props["filter_reciter_name"])
         self.assertEqual([self.reciter.name], props["filter_reciter_names"])
+
+    @override_settings(ENABLE_API_KEY_AUTH=True)
+    @patch(_REDIS)
+    def test_api_key_request_records_key_prefix_as_application_identity(self, mock_get_redis):
+        api_key, raw_key = APIKey.objects.create_key(
+            name="Tracking App",
+            user=self.user,
+        )
+
+        response = self.client.get(
+            "/recitations/",
+            headers={"x-api-key": raw_key},
+        )
+
+        self.assertEqual(200, response.status_code, response.content)
+
+        props = self._props(mock_get_redis)
+
+        self.assertEqual(api_key.prefix, props["application_id"])
+        self.assertIsNone(props["application_name"])
+
+    @override_settings(ENABLE_API_KEY_AUTH=True)
+    @patch(_REDIS)
+    def test_api_keys_for_same_user_record_distinct_application_ids(self, mock_get_redis):
+        first_key, first_raw = APIKey.objects.create_key(
+            name="App One",
+            user=self.user,
+        )
+        second_key, second_raw = APIKey.objects.create_key(
+            name="App Two",
+            user=self.user,
+        )
+
+        first_response = self.client.get(
+            "/recitations/",
+            headers={"x-api-key": first_raw},
+        )
+        second_response = self.client.get(
+            "/recitations/",
+            headers={"x-api-key": second_raw},
+        )
+
+        self.assertEqual(200, first_response.status_code, first_response.content)
+        self.assertEqual(200, second_response.status_code, second_response.content)
+
+        calls = mock_get_redis.return_value.rpush.call_args_list
+        first_props = json.loads(calls[-2].args[1])["properties"]
+        second_props = json.loads(calls[-1].args[1])["properties"]
+
+        self.assertEqual(first_key.prefix, first_props["application_id"])
+        self.assertEqual(second_key.prefix, second_props["application_id"])
+        self.assertNotEqual(
+            first_props["application_id"],
+            second_props["application_id"],
+        )
 
 
 class ResolveReciterNameTest(BaseTestCase):

--- a/apps/core/ninja_utils/auth.py
+++ b/apps/core/ninja_utils/auth.py
@@ -33,9 +33,11 @@ internal_auth = [SessionToken()]
 class ApiKeyAuth(BaseApiKeyAuth):
     """API key auth that binds the key's owner to ``request.user``.
 
-    The upstream ``ApiKeyAuth.authenticate`` only returns a boolean, so the
-    consumer identity is lost. Per-asset access checks (access requests) need the
-    actual user, so we resolve the key to its owner and set ``request.user``.
+    The resolved ``APIKey`` itself is returned so Django Ninja exposes it as
+    ``request.auth``. Usage tracking can then use the key's non-secret prefix for
+    per-app attribution without re-resolving the raw X-API-Key header.
+    ``request.user`` is still set to the key's owner for per-asset access checks
+    and user-scoped permissions.
     """
 
     def authenticate(self, request, key):
@@ -50,7 +52,7 @@ class ApiKeyAuth(BaseApiKeyAuth):
             raise AuthenticationError(message=str(_("API key has expired.")))
 
         request.user = api_key.user
-        return api_key.user
+        return api_key
 
 
 class PublicAuth:

--- a/apps/usage_tracking/decorators/track_usage.py
+++ b/apps/usage_tracking/decorators/track_usage.py
@@ -318,15 +318,20 @@ def _prefer_arabic_name(row: dict) -> str:
     return (row.get("name_ar") or "") or (row.get("name_en") or "")
 
 
-def _resolve_application(request) -> tuple[int | None, str | None]:
-    """Return (application_id, application_name) for OAuth2-authed requests."""
+def _resolve_application(request) -> tuple[int | str | None, str | None]:
+    """Return the application identity for OAuth2 or API-key requests."""
     token = getattr(request, "access_token", None)
-    if token is None:
-        return None, None
-    application = getattr(token, "application", None)
-    if application is None:
-        return None, None
-    return getattr(application, "id", None), getattr(application, "name", None)
+    if token is not None:
+        application = getattr(token, "application", None)
+        if application is not None:
+            return getattr(application, "id", None), getattr(application, "name", None)
+
+    auth = getattr(request, "auth", None)
+    prefix = getattr(auth, "prefix", None)
+    if prefix:
+        return prefix, None
+
+    return None, None
 
 
 def _detect_auth_method(request) -> str:

--- a/apps/usage_tracking/tests/test_track_usage.py
+++ b/apps/usage_tracking/tests/test_track_usage.py
@@ -262,6 +262,26 @@ class TestTrackUsageDecorator:
         assert "properties" in payload
         assert "meta" in payload
 
+    @patch("apps.usage_tracking.decorators.track_usage._get_tracking_redis")
+    def test_api_key_application_identity_is_dispatched(self, mock_get_redis):
+        mock_r = MagicMock()
+        mock_get_redis.return_value = mock_r
+
+        @track_usage()
+        def view(request):
+            return {"results": [], "count": 0}
+
+        request = self.factory.get("/recitations/")
+        request.user = SimpleNamespace(pk=99, is_authenticated=True)
+        request.auth = SimpleNamespace(prefix="app12345")
+
+        view(request)
+
+        props = _dispatched_props(mock_r)
+
+        assert props["application_id"] == "app12345"
+        assert props["application_name"] is None
+
 
 class TestDistinctId:
     def setup_method(self):
@@ -332,6 +352,21 @@ class TestResolveApplication:
     def test_token_with_application(self):
         request = SimpleNamespace(access_token=SimpleNamespace(application=SimpleNamespace(id=7, name="my-app")))
         assert _resolve_application(request) == (7, "my-app")
+
+    def test_api_key_auth_uses_key_prefix_as_application_id(self):
+        request = SimpleNamespace(
+            auth=SimpleNamespace(prefix="app12345"),
+        )
+        assert _resolve_application(request) == ("app12345", None)
+
+    def test_oauth_application_takes_precedence_over_api_key_auth(self):
+        request = SimpleNamespace(
+            access_token=SimpleNamespace(
+                application=SimpleNamespace(id=7, name="oauth-app"),
+            ),
+            auth=SimpleNamespace(prefix="app12345"),
+        )
+        assert _resolve_application(request) == (7, "oauth-app")
 
 
 class TestClientIp:


### PR DESCRIPTION
## Summary

Implements the API-key app-attribution portion of #411.

API-key authenticated requests now expose the already-resolved `APIKey` through `request.auth`, allowing usage tracking to use the key's non-secret prefix as the existing `application_id`.

## Changes

* Preserve `request.user = api_key.user` for existing access checks and permissions.
* Return the resolved `APIKey` so Django Ninja exposes it as `request.auth`.
* Use `request.auth.prefix` as `application_id` for API-key traffic.
* Preserve existing OAuth2 application resolution and precedence.
* Avoid re-reading or re-resolving the raw `X-API-Key` header.
* Keep existing `auth_method` and `distinct_id` behavior unchanged.
* Keep attribution Mixpanel-only; no additional DB persistence or tracking-path queries were introduced.
* Add integration coverage proving two API keys owned by the same user produce distinct application identities.

## Tests

* `apps/usage_tracking/tests/test_track_usage.py`: **30 passed**
* `apps/content/tests/public/test_usage_tracking_integration.py`: **17 passed**
* `apps/usage_tracking/tests/`: **85 passed, 4 skipped**
* Ruff: **All checks passed**
* `git diff --check`: **clean**

`apps/users/tests/test_api_key_auth.py` contains 4 tests that are skipped under the current test configuration. The successful API-key authentication path is covered by the new end-to-end integration tests.

## Scope

This PR implements the API-key app-attribution portion of #411.

Downstream per-end-user Mixpanel enrichment remains pending until #410 establishes the validated request-context contract.

Refs #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Usage Tracking**
  - API-key requests now record each key’s prefix as the application identifier.
  - Requests using different API keys are tracked as separate applications, even when owned by the same account.
  - OAuth application details continue to take precedence when both authentication methods are present.
  - Requests without recognized application credentials no longer receive an application identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->