### PR TITLE
fix(content): enforce access control and private caching on public recitation tracks

### DIFF
--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -77,7 +77,15 @@ def list_recitation_tracks(
     cached_resp: bytes | None = cache.get(_resp_key)
     cached_meta: dict | None = cache.get(_meta_key)
 
-    if cached_resp is not None and cached_meta is not None:
+    if cached_resp is not None and cached_meta is not None and "is_open_access" in cached_meta:
+        is_open_access: bool = cached_meta["is_open_access"]
+        if not is_open_access:
+            enforce_asset_access_on_public_api(
+                getattr(request, "user", None),
+                asset_id=asset_id,
+                is_open_access=is_open_access,
+            )
+
         track_extra(
             request,
             entity_type="recitation_track",
@@ -88,7 +96,7 @@ def list_recitation_tracks(
             publisher_names=[cached_meta["publisher_name"]] if cached_meta["publisher_id"] else [],
         )
         resp = HttpResponse(cached_resp, content_type="application/json")
-        resp["Cache-Control"] = "public, max-age=300, s-maxage=300"
+        resp["Cache-Control"] = "public, max-age=300, s-maxage=300" if is_open_access else "private, no-cache"
         return resp
 
     # Cache miss - hit DB.
@@ -107,6 +115,7 @@ def list_recitation_tracks(
         "name_ar": asset.name_ar,
         "publisher_id": asset.publisher_id,
         "publisher_name": publisher_name,
+        "is_open_access": asset.is_open_access,
     }
 
     track_extra(
@@ -165,5 +174,5 @@ def list_recitation_tracks(
     cache.set(_meta_key, asset_meta, RECITATION_ASSET_META_CACHE_TTL)
 
     resp = HttpResponse(response_bytes, content_type="application/json")
-    resp["Cache-Control"] = "public, max-age=300, s-maxage=300"
+    resp["Cache-Control"] = "public, max-age=300, s-maxage=300" if asset.is_open_access else "private, no-cache"
     return resp

--- a/apps/content/services/asset_access.py
+++ b/apps/content/services/asset_access.py
@@ -160,7 +160,28 @@ def guard_restrict_for_tenant(asset: Asset) -> None:
     )
 
 
-def enforce_asset_access_on_public_api(user: User | None, asset: Asset) -> None:
+def user_has_asset_id_access(user: User, asset_id: int) -> bool:
+    try:
+        access = AssetAccess.objects.get(user=user, asset_id=asset_id)
+        return access.is_active
+    except AssetAccess.DoesNotExist:
+        return False
+
+
+def user_has_access(user: User, asset: Asset) -> bool:
+    if asset.is_open_access:
+        return True
+
+    return user_has_asset_id_access(user, asset.pk)
+
+
+def enforce_asset_access_on_public_api(
+    user: User | None,
+    asset: Asset | None = None,
+    *,
+    asset_id: int | None = None,
+    is_open_access: bool | None = None,
+) -> None:
     """Gate consumption of an asset's content behind an API key + approved access.
 
     Open-access assets are free to consume by anyone. For assets the publisher keeps
@@ -173,7 +194,8 @@ def enforce_asset_access_on_public_api(user: User | None, asset: Asset) -> None:
     if not settings.ENFORCE_ASSET_ACCESS_ON_PUBLIC_API:
         return
 
-    if asset.is_open_access:
+    open_access = asset.is_open_access if asset is not None else bool(is_open_access)
+    if open_access:
         return
 
     if not (user and user.is_authenticated):
@@ -183,23 +205,13 @@ def enforce_asset_access_on_public_api(user: User | None, asset: Asset) -> None:
             status_code=401,
         )
 
-    if not user_has_access(user, asset):
+    target_asset_id = asset.pk if asset is not None else asset_id
+    if target_asset_id is None or not user_has_asset_id_access(user, target_asset_id):
         raise ItqanError(
             "access_denied",
             _("You don't have an approved access request for this asset."),
             status_code=403,
         )
-
-
-def user_has_access(user: User, asset: Asset) -> bool:
-    if asset.is_open_access:
-        return True
-
-    try:
-        access = AssetAccess.objects.get(user=user, asset=asset)
-        return access.is_active
-    except AssetAccess.DoesNotExist:
-        return False
 
 
 class AssetAccessStatus(str, Enum):

--- a/apps/content/tests/public/test_recitation_detail.py
+++ b/apps/content/tests/public/test_recitation_detail.py
@@ -358,7 +358,10 @@ class RecitationTracksAccessControlTest(BaseTestCase):
     """Gating of the content endpoint behind API key + approved access request."""
 
     def setUp(self):
+        from django.core.cache import cache as django_cache
+
         super().setUp()
+        django_cache.clear()
         self.publisher = baker.make(Publisher)
         self.asset = baker.make(
             Asset,
@@ -399,6 +402,7 @@ class RecitationTracksAccessControlTest(BaseTestCase):
         response = self.client.get(f"/recitations/{self.asset.id}/")
 
         self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual("public, max-age=300, s-maxage=300", response.headers.get("Cache-Control"))
 
     def test_restricted_asset_without_api_key_returns_401(self):
         response = self.client.get(f"/recitations/{self.asset.id}/")
@@ -450,6 +454,96 @@ class RecitationTracksAccessControlTest(BaseTestCase):
 
         self.assertEqual(200, response.status_code, response.content)
         self.assertEqual(1, len(response.json()["results"]))
+        self.assertEqual("private, no-cache", response.headers.get("Cache-Control"))
+
+    def test_restricted_asset_warm_cache_still_rejects_unauthenticated_request(self):
+        # 1. Warm cache with an authorized request
+        self._grant_access(self.user, self.asset)
+        self._authenticate_with_api_key(self.user)
+        auth_response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, auth_response.status_code, auth_response.content)
+
+        # 2. Subsequent unauthenticated request must be rejected (not served from cache)
+        self.client.credentials()  # Remove API key
+        anon_response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(401, anon_response.status_code, anon_response.content)
+        self.assertEqual("authentication_required", anon_response.json()["error_name"])
+
+    def test_restricted_asset_warm_cache_still_rejects_unauthorized_user(self):
+        # 1. Warm cache with User A (authorized)
+        self._grant_access(self.user, self.asset)
+        self._authenticate_with_api_key(self.user)
+        auth_response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, auth_response.status_code, auth_response.content)
+
+        # 2. Request from User B (authenticated, but has no access grant)
+        other_user = User.objects.create_user(email="other_dev@example.com", name="Other Dev")
+        self._authenticate_with_api_key(other_user)
+        unauth_response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(403, unauth_response.status_code, unauth_response.content)
+        self.assertEqual("access_denied", unauth_response.json()["error_name"])
+
+    def test_restricted_asset_warm_cache_serves_another_authorized_user(self):
+        # 1. User A warms cache
+        self._grant_access(self.user, self.asset)
+        self._authenticate_with_api_key(self.user)
+        resp_a = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, resp_a.status_code, resp_a.content)
+
+        # 2. User B (also authorized) hits cache
+        user_b = User.objects.create_user(email="dev_b@example.com", name="Dev B")
+        self._grant_access(user_b, self.asset)
+        self._authenticate_with_api_key(user_b)
+        resp_b = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, resp_b.status_code, resp_b.content)
+        self.assertEqual(resp_a.json(), resp_b.json())
+        self.assertEqual("private, no-cache", resp_b.headers.get("Cache-Control"))
+
+    def test_restricted_asset_legacy_cache_without_is_open_access_falls_back_to_db_and_enforces_access(self):
+        import json
+
+        from django.core.cache import cache as django_cache
+
+        from apps.content.cache import (
+            DEFAULT_FOLDER_CACHE_TOKEN,
+            RECITATION_ASSET_META_CACHE_TTL,
+            RECITATION_RESPONSE_CACHE_TTL,
+            recitation_asset_meta_cache_key,
+            recitation_response_cache_key,
+        )
+
+        # Simulate legacy cache entry (populated before deployment) missing "is_open_access"
+        resp_key = recitation_response_cache_key(
+            self.asset.id, page=1, page_size=DEFAULT_PAGE_SIZE, folder_slug=DEFAULT_FOLDER_CACHE_TOKEN
+        )
+        meta_key = recitation_asset_meta_cache_key(self.asset.id)
+
+        legacy_meta = {
+            "name_ar": self.asset.name_ar,
+            "publisher_id": self.asset.publisher_id,
+            "publisher_name": self.asset.publisher.name,
+            # Notice: "is_open_access" is absent!
+        }
+        legacy_resp = json.dumps({"results": [], "count": 0}).encode()
+
+        django_cache.set(resp_key, legacy_resp, RECITATION_RESPONSE_CACHE_TTL)
+        django_cache.set(meta_key, legacy_meta, RECITATION_ASSET_META_CACHE_TTL)
+
+        # Unauthenticated request must NOT be served from cache; it must hit DB and return 401
+        response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(401, response.status_code, response.content)
+        self.assertEqual("authentication_required", response.json()["error_name"])
+
+        # Authenticated request with approved grant updates cache with new schema
+        self._grant_access(self.user, self.asset)
+        self._authenticate_with_api_key(self.user)
+        auth_response = self.client.get(f"/recitations/{self.asset.id}/")
+        self.assertEqual(200, auth_response.status_code, auth_response.content)
+
+        # Verify cache meta now includes "is_open_access"
+        updated_meta = django_cache.get(meta_key)
+        self.assertIn("is_open_access", updated_meta)
+        self.assertFalse(updated_meta["is_open_access"])
 
     @override_settings(ENFORCE_ASSET_ACCESS_ON_PUBLIC_API=False)
     def test_flag_off_restricted_asset_consumable_without_api_key(self):


### PR DESCRIPTION
Fixes a critical authorization bypass and data leak vulnerability in the public recitation tracks endpoint (GET /api/public/recitations/{asset_id}/).

Previously, warm cache hits returned pre-serialized track and ayah-timing JSON payloads immediately without evaluating asset access controls or checking the caller's authorization state. Once an authorized developer accessed a restricted asset (is_open_access=False), the response was cached in Redis under a non-partitioned key and served to any subsequent unauthenticated or unauthorized caller. In addition, Cache-Control: public exposed restricted payloads to shared edge/CDN proxies.


### Root Cause
- Unconditional Cache Return: list_recitation_tracks returned HttpResponse(cached_resp) on warm hits before reaching enforce_asset_access_on_public_api.
- Missing Metadata in Cache: recitation_asset_meta_cache_key did not preserve is_open_access, preventing permission checks on cache hits without a database query.
- Unscoped Cache-Control Header: The endpoint unconditionally returned Cache-Control: public, max-age=300, s-maxage=300, allowing CDNs (e.g. Cloudflare) to cache and distribute restricted asset data globally.

**Note**: Pre-deployment metadata entries missing "is_open_access" are treated as a cache miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Restricted recitation content is now protected consistently, including cached responses.
* Unauthorized and unauthenticated requests can no longer receive cached restricted content.
* Cache headers correctly mark open-access content as public and restricted content as private and non-cacheable.
* Authorized users continue to receive restricted content as expected.
* Older cached responses without access metadata are now revalidated before delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->