### PR TITLE
Fix stable anon distinct_id for public API usage tracking

### DIFF
--- a/apps/usage_tracking/decorators/track_usage.py
+++ b/apps/usage_tracking/decorators/track_usage.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
+import hashlib
 import json
 import logging
 import time
@@ -24,6 +25,7 @@ from urllib.parse import parse_qs
 import uuid
 
 from django.core.cache import cache
+from django.utils import timezone
 
 from apps.usage_tracking.tasks import TRACKING_BUFFER_KEY, _get_tracking_redis
 
@@ -400,6 +402,18 @@ def _distinct_id(request) -> str:
     if user is not None and getattr(user, "is_authenticated", False):
         return f"user-{user.pk}"
 
-    # True anonymous -- every request gets a fresh ID. Acceptable; we have no better
-    # signal. Most public-API traffic should hit one of the branches above.
+    # True anonymous -- derive a day-stable id from ip+user-agent+date so repeat
+    # requests from the same device on the same day count as one Mixpanel-tracked
+    # user instead of one per request (a fresh uuid4 here was inflating tracked-user
+    # volume 1:1 with request volume). Rotating daily bounds mobile-carrier-NAT
+    # collapse (many real devices sharing one egress IP) to a single day, rather than
+    # merging them permanently.
+    ip = _client_ip(request)
+    if ip:
+        user_agent = request.headers.get("user-agent") or ""
+        day = timezone.now().strftime("%Y-%m-%d")
+        digest = hashlib.sha256(f"{ip}:{user_agent}:{day}".encode()).hexdigest()[:12]
+        return f"anon-{digest}"
+
+    # No ip available (should not happen outside tests) -- fall back to a fresh id.
     return f"anon-{uuid.uuid4().hex[:12]}"

--- a/apps/usage_tracking/tests/test_track_usage.py
+++ b/apps/usage_tracking/tests/test_track_usage.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
+from freezegun import freeze_time
 
 from apps.usage_tracking.decorators.track_usage import (
     _client_ip,
@@ -277,12 +278,54 @@ class TestDistinctId:
         request.user = SimpleNamespace(pk=99, is_authenticated=True)
         assert _distinct_id(request) == "user-99"
 
-    def test_anonymous_falls_back_to_uuid(self):
-        request = self.factory.get("/recitations/")
-        request.user = AnonymousUser()
-        result = _distinct_id(request)
-        assert result.startswith("anon-")
-        assert len(result) == 17  # "anon-" + 12 hex chars
+    def test_anonymous_same_ip_and_user_agent_same_day_yields_same_id(self):
+        with freeze_time("2026-08-20"):
+            request1 = self.factory.get("/recitations/", REMOTE_ADDR="9.9.9.9", HTTP_USER_AGENT="okhttp/4.12.0")
+            request1.user = AnonymousUser()
+            request2 = self.factory.get("/reciters/", REMOTE_ADDR="9.9.9.9", HTTP_USER_AGENT="okhttp/4.12.0")
+            request2.user = AnonymousUser()
+            result1 = _distinct_id(request1)
+            result2 = _distinct_id(request2)
+
+        assert result1 == result2
+        assert result1.startswith("anon-")
+        assert len(result1) == 17  # "anon-" + 12 hex chars
+
+    def test_anonymous_different_ip_yields_different_id(self):
+        with freeze_time("2026-08-20"):
+            request1 = self.factory.get("/recitations/", REMOTE_ADDR="9.9.9.9", HTTP_USER_AGENT="okhttp/4.12.0")
+            request1.user = AnonymousUser()
+            request2 = self.factory.get("/recitations/", REMOTE_ADDR="1.1.1.1", HTTP_USER_AGENT="okhttp/4.12.0")
+            request2.user = AnonymousUser()
+            assert _distinct_id(request1) != _distinct_id(request2)
+
+    def test_anonymous_different_day_yields_different_id(self):
+        """Daily rotation bounds carrier-NAT collapse to a single day."""
+        kwargs = {"REMOTE_ADDR": "9.9.9.9", "HTTP_USER_AGENT": "okhttp/4.12.0"}
+        with freeze_time("2026-08-20"):
+            request1 = self.factory.get("/recitations/", **kwargs)
+            request1.user = AnonymousUser()
+            result_day1 = _distinct_id(request1)
+        with freeze_time("2026-08-21"):
+            request2 = self.factory.get("/recitations/", **kwargs)
+            request2.user = AnonymousUser()
+            result_day2 = _distinct_id(request2)
+        assert result_day1 != result_day2
+
+    def test_anonymous_without_ip_falls_back_to_fresh_uuid(self):
+        request1 = self.factory.get("/recitations/")
+        del request1.META["REMOTE_ADDR"]
+        request1.user = AnonymousUser()
+        request2 = self.factory.get("/recitations/")
+        del request2.META["REMOTE_ADDR"]
+        request2.user = AnonymousUser()
+
+        result1 = _distinct_id(request1)
+        result2 = _distinct_id(request2)
+
+        assert result1.startswith("anon-")
+        assert len(result1) == 17  # "anon-" + 12 hex chars
+        assert result1 != result2  # fresh per request, unlike the ip-keyed path above
 
 
 class TestDetectAuthMethod:


### PR DESCRIPTION
## Summary
Anonymous public API requests got a fresh random Mixpanel id on every single call, so one real device making N requests looked like N different users. This changes it to a day-stable id (ip + user-agent + date), so repeat requests from the same device on the same day count once. It rotates daily on purpose, so devices sharing a mobile carrier's IP don't get permanently merged into one identity.

Part of investigating the Aug 2 Mixpanel invoice spike. Confirmed live in prod that current anonymous tracking is 100% fresh-uuid ids.

Heads up: this fixes identity inflation and should make the publisher analytics boards more accurate, but it's not confirmed to lower the Mixpanel bill. That depends on whether the plan charges by tracked users or by raw events, which I haven't been able to check yet.

## Test plan
- `uv run pytest apps/usage_tracking/tests/test_track_usage.py`, 30/30 passing, including new tests for same id/day, different ip, different day, and the no-ip fallback
- ruff check and ruff format clean
- DB-backed suite not run locally, no local Postgres, this change doesn't touch the DB

Not merged yet, opened for review.