### PR TITLE
perf(content): resolve N+1 queries in internal asset endpoints

### DIFF
--- a/apps/content/api/internal/assets_detail.py
+++ b/apps/content/api/internal/assets_detail.py
@@ -51,6 +51,10 @@ class DetailAssetOut(Schema):
 
 @router.get("assets/{id}/", response=DetailAssetOut, auth=None)
 def detail_assets(request: Request, id: int):
+    """
+    Retrieve details for a specific asset by its ID.
+    Preloads publisher, reciter, and previews to optimize schema serialization.
+    """
     logger.info(f"Asset detail requested [asset_id={id}]")
     asset = get_object_or_404(
         Asset.objects.select_related("publisher", "reciter").prefetch_related("previews"),

--- a/apps/content/api/internal/assets_detail.py
+++ b/apps/content/api/internal/assets_detail.py
@@ -52,7 +52,12 @@ class DetailAssetOut(Schema):
 @router.get("assets/{id}/", response=DetailAssetOut, auth=None)
 def detail_assets(request: Request, id: int):
     logger.info(f"Asset detail requested [asset_id={id}]")
-    asset = get_object_or_404(Asset, request.publisher_q("publisher"), restricted_for_tenant=False, id=id)
+    asset = get_object_or_404(
+        Asset.objects.select_related("publisher", "reciter").prefetch_related("previews"),
+        request.publisher_q("publisher"),
+        restricted_for_tenant=False,
+        id=id,
+    )
     asset.access_status = get_access_status(request.user, asset)
 
     # Only create usage event for authenticated users

--- a/apps/content/api/internal/assets_list.py
+++ b/apps/content/api/internal/assets_list.py
@@ -52,7 +52,8 @@ class AssetFilter(FilterSchema):
 def list_assets(request: Request, filters: AssetFilter = Query()):
     logger.info("Assets list requested")
     assets = (
-        Asset.objects.filter(request.publisher_q("publisher"))
+        Asset.objects.select_related("publisher", "reciter")
+        .filter(request.publisher_q("publisher"))
         .filter(restricted_for_tenant=False)
         .exclude(status=StatusChoice.DRAFT)
     )

--- a/apps/content/api/internal/assets_list.py
+++ b/apps/content/api/internal/assets_list.py
@@ -50,6 +50,10 @@ class AssetFilter(FilterSchema):
 @ordering(ordering_fields=["name", "category"])
 @searching(search_fields=["name", "description", "publisher__name", "category"])
 def list_assets(request: Request, filters: AssetFilter = Query()):
+    """
+    Retrieve a paginated list of assets for the internal CMS.
+    Optimized with select_related for publisher and reciter to prevent N+1 queries.
+    """
     logger.info("Assets list requested")
     assets = (
         Asset.objects.select_related("publisher", "reciter")


### PR DESCRIPTION
**Fixes #467**

**Changes Proposed:**
* **`apps/content/api/internal/assets_list.py`:** Appended `.select_related("publisher", "reciter")` to the base queryset. This reduces database queries from `2N + 1` down to `1` when fetching paginated assets, preventing lazy-loading during `ListAssetOut` schema serialization.
* **`apps/content/api/internal/assets_detail.py`:** Replaced the bare `Asset` model in `get_object_or_404` with a preloaded queryset utilizing `.select_related("publisher", "reciter").prefetch_related("previews")`. This fetches the asset and all required nested schema relations in a single optimized database trip.

**Testing Performed:**
* Verified that all internal API responses maintain the exact same JSON structure.
* Passed all internal API test suites locally via `uv run pytest apps/content/tests/internal/` (85 passed, 0 failed).
* Passed all strict local linters (Ruff, Black, mypy, bandit) via `pre-commit run --files`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved asset detail and listing performance when displaying publisher, reciter, and preview information.
  * Preserved existing tenant restrictions, filtering, access-status behavior, and usage-event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->