### PR TITLE
fix(publishers): handle invitations with missing member

### DIFF
--- a/apps/publishers/services/publisher_member_invitation_service.py
+++ b/apps/publishers/services/publisher_member_invitation_service.py
@@ -95,6 +95,12 @@ class PublisherMemberInvitationService:
                 message=_("Only pending invitations can be resent."),
                 status_code=400,
             )
+        if invitation.member_id is None:
+            raise ItqanError(
+                error_name="invalid_invitation",
+                message=_("This invitation is no longer valid."),
+                status_code=400,
+            )
         member = invitation.member
         now = timezone.now()
         self.repo.cancel_pending_invitations(member=member, cancelled_by=actor, now=now)
@@ -107,6 +113,12 @@ class PublisherMemberInvitationService:
             raise ItqanError(
                 error_name="invalid_invitation",
                 message=_("Only pending invitations can be cancelled."),
+                status_code=400,
+            )
+        if invitation.member_id is None:
+            raise ItqanError(
+                error_name="invalid_invitation",
+                message=_("This invitation is no longer valid."),
                 status_code=400,
             )
         now = timezone.now()

--- a/apps/publishers/tests/services/test_publisher_member_invitation_service.py
+++ b/apps/publishers/tests/services/test_publisher_member_invitation_service.py
@@ -217,3 +217,35 @@ class InvitationServiceTest(BaseTestCase):
         with self.assertRaises(ItqanError) as ctx:
             self.service.accept_invitation(raw)
         self.assertEqual("invalid_invitation", ctx.exception.error_name)
+
+    def test_resend_where_member_is_none_should_raise_invalid_invitation(self):
+        # Arrange: a pending invitation whose member row was deleted (member_id -> NULL).
+        member, inv, _, _ = self._create(email="orphan-resend@example.com")
+        member.delete()
+        inv.refresh_from_db()
+        self.assertIsNone(inv.member_id)
+        self.assertEqual(PublisherMemberInvitation.StatusChoice.PENDING, inv.status)
+
+        # Act
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.resend(inv, self.inviter)
+
+        # Assert
+        self.assertEqual("invalid_invitation", ctx.exception.error_name)
+        self.assertEqual(400, ctx.exception.status_code)
+
+    def test_cancel_where_member_is_none_should_raise_invalid_invitation(self):
+        # Arrange: a pending invitation whose member row was deleted (member_id -> NULL).
+        member, inv, _, _ = self._create(email="orphan-cancel@example.com")
+        member.delete()
+        inv.refresh_from_db()
+        self.assertIsNone(inv.member_id)
+        self.assertEqual(PublisherMemberInvitation.StatusChoice.PENDING, inv.status)
+
+        # Act
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.cancel(inv, self.inviter)
+
+        # Assert
+        self.assertEqual("invalid_invitation", ctx.exception.error_name)
+        self.assertEqual(400, ctx.exception.status_code)

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -682,11 +682,11 @@ msgstr "هذا المستخدم عضو بالفعل لدى هذا الناشر."
 msgid "Only pending invitations can be resent."
 msgstr "يمكن إعادة إرسال الدعوات المعلقة فقط."
 
-msgid "Only pending invitations can be cancelled."
-msgstr "يمكن إلغاء الدعوات المعلقة فقط."
-
 msgid "This invitation is no longer valid."
 msgstr "هذه الدعوة لم تعد صالحة."
+
+msgid "Only pending invitations can be cancelled."
+msgstr "يمكن إلغاء الدعوات المعلقة فقط."
 
 msgid "Sura does not exist."
 msgstr "السورة غير موجودة."


### PR DESCRIPTION
Fixes #457

## Summary
- Guard `resend()` when the invitation member no longer exists.
- Guard `cancel()` against the same orphaned invitation state.
- Return a clean `invalid_invitation` 400 error instead of an unhandled exception.
- Add regression tests for both cases.

## Testing
- Publisher invitation service tests: 15 passed
- Publisher member detail tests: 11 passed
- pre-commit checks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid invitations whose associated member is no longer available.
  - Resending or canceling these invitations now returns a clear error message with HTTP status 400 instead of proceeding unsuccessfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->