### PR TITLE
feat(recitations): add folder visibility and set-default portal support

### DIFF
--- a/apps/content/api/portal/recitation_folders.py
+++ b/apps/content/api/portal/recitation_folders.py
@@ -29,6 +29,7 @@ class FolderOut(Schema):
     name_en: str | None = None
     slug: str
     is_default: bool
+    is_visible: bool
     tracks_count: int = 0
     created_at: AwareDatetime
     updated_at: AwareDatetime
@@ -46,6 +47,8 @@ class FolderCreateIn(Schema):
 class FolderPatchIn(Schema):
     name_ar: str | None = Field(default=None, max_length=255)
     name_en: str | None = Field(default=None, max_length=255)
+    is_visible: bool | None = None
+    is_default: bool | None = None
 
 
 # --- Helpers ---
@@ -107,7 +110,14 @@ def create_folder(request: Request, recitation_slug: str, data: FolderCreateIn):
     "recitations/{recitation_slug}/folders/{folder_slug}/",
     response={
         200: FolderOut,
-        400: NinjaErrorResponse[Literal["folder_name_required"]],
+        400: NinjaErrorResponse[
+            Literal[
+                "folder_name_required",
+                "cannot_hide_default_folder",
+                "cannot_unset_default_folder",
+                "cannot_set_hidden_folder_as_default",
+            ]
+        ],
         401: NinjaErrorResponse[Literal["authentication_error"]],
         403: NinjaErrorResponse[Literal["permission_denied"]],
         404: NinjaErrorResponse[Literal["recitation_not_found"]] | NinjaErrorResponse[Literal["folder_not_found"]],

--- a/apps/content/api/portal/recitations.py
+++ b/apps/content/api/portal/recitations.py
@@ -129,7 +129,7 @@ class RecitationDetailOut(Schema):
         versions = list(obj.versions.all())
 
         version = None
-        if default_folder:
+        if default_folder and default_folder.is_visible:
             version = next((v for v in versions if v.name == default_folder.slug), None)
         if version is None:
             # Recitations created before folders may still have a legacy version row.

--- a/apps/content/api/portal/recitations.py
+++ b/apps/content/api/portal/recitations.py
@@ -57,6 +57,7 @@ class FolderOut(Schema):
     name: str
     slug: str
     is_default: bool
+    is_visible: bool
 
 
 class RecitationListOut(Schema):

--- a/apps/content/api/public/recitation_list.py
+++ b/apps/content/api/public/recitation_list.py
@@ -6,7 +6,7 @@ from ninja.pagination import paginate
 
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
-from apps.content.services.recitation_folder_resolution import sorted_asset_folders
+from apps.content.services.recitation_folder_resolution import visible_asset_folders
 from apps.core.ninja_utils.ordering_base import ordering
 from apps.core.ninja_utils.router import ItqanRouter
 from apps.core.ninja_utils.searching_base import searching
@@ -77,7 +77,7 @@ class RecitationListOut(Schema):
     @staticmethod
     def resolve_folders(obj):
         # Lets a consumer discover which ?folder= values this recitation accepts.
-        return sorted_asset_folders(obj)
+        return visible_asset_folders(obj)
 
 
 class RecitationFilter(FilterSchema):

--- a/apps/content/api/public/recitation_track_list.py
+++ b/apps/content/api/public/recitation_track_list.py
@@ -124,6 +124,7 @@ def list_recitation_tracks(
         Q(asset__restricted_for_tenant=False),
         prefetch_timings=True,
         folder=folder,
+        require_visible_folder=True,
     )
 
     all_results = []

--- a/apps/content/api/tenant/recitation_list.py
+++ b/apps/content/api/tenant/recitation_list.py
@@ -6,7 +6,7 @@ from ninja.pagination import paginate
 from apps.content.models import Asset
 from apps.content.repositories.recitation import RecitationRepository
 from apps.content.services.recitation import RecitationService
-from apps.content.services.recitation_folder_resolution import sorted_asset_folders
+from apps.content.services.recitation_folder_resolution import visible_asset_folders
 from apps.core.ninja_utils.ordering_base import ordering
 from apps.core.ninja_utils.request import Request
 from apps.core.ninja_utils.router import ItqanRouter
@@ -54,7 +54,7 @@ class RecitationListOut(Schema):
     @staticmethod
     def resolve_folders(obj):
         # Lets a consumer discover which ?folder= values this recitation accepts.
-        return sorted_asset_folders(obj)
+        return visible_asset_folders(obj)
 
 
 class RecitationFilter(FilterSchema):

--- a/apps/content/api/tenant/recitation_track_list.py
+++ b/apps/content/api/tenant/recitation_track_list.py
@@ -62,6 +62,8 @@ def list_recitation_tracks(request: Request, asset_id: int, folder: str | None =
     if not asset:
         raise Http404(str(_("No asset matches the given query.")))
 
-    tracks = service.get_asset_tracks(asset_id, request.publisher_q("asset__publisher"), folder=folder)
+    tracks = service.get_asset_tracks(
+        asset_id, request.publisher_q("asset__publisher"), folder=folder, require_visible_folder=True
+    )
 
     return tracks

--- a/apps/content/cache.py
+++ b/apps/content/cache.py
@@ -3,6 +3,8 @@ import re
 
 from django.core.cache import cache
 
+from apps.core.ninja_utils.paginations import DEFAULT_PAGE_SIZE, PUBLIC_RECITATION_MAX_PAGE_SIZE
+
 # Stands in for "caller did not name a folder" in cache keys, so the default-folder
 # response gets its own entry without a DB lookup to resolve the real slug.
 DEFAULT_FOLDER_CACHE_TOKEN = "__default__"
@@ -62,3 +64,24 @@ def invalidate_recitation_tracks_cache(asset_id: int) -> None:
             recitation_asset_meta_cache_key(asset_id),
         ]
     )
+
+
+def invalidate_recitation_folder_cache(asset_id: int, folder) -> None:
+    """
+    Bust public recitation caches after a folder's visibility or default status changes.
+
+    Per-folder response keys for every page size cannot be enumerated cheaply, so the
+    asset meta key is cleared to force rebuilds; known folder tokens are deleted when
+    present so the common first-page case is immediate.
+    """
+    invalidate_recitation_tracks_cache(asset_id)
+
+    tokens = {folder.slug, folder_cache_token(folder.slug)}
+    for name in (folder.name, folder.name_ar, folder.name_en):
+        if name:
+            tokens.add(folder_cache_token(name))
+
+    for token in tokens:
+        for page in (1,):
+            for page_size in (DEFAULT_PAGE_SIZE, PUBLIC_RECITATION_MAX_PAGE_SIZE):
+                cache.delete(recitation_response_cache_key(asset_id, page, page_size, token))

--- a/apps/content/migrations/0050_recitationfolder_is_visible.py
+++ b/apps/content/migrations/0050_recitationfolder_is_visible.py
@@ -16,12 +16,4 @@ class Migration(migrations.Migration):
                 help_text="When false, the folder is omitted from public/tenant APIs and its timings export is withdrawn.",
             ),
         ),
-        migrations.AddIndex(
-            model_name="recitationfolder",
-            index=models.Index(
-                condition=models.Q(("is_visible", True)),
-                fields=["asset"],
-                name="content_recitationfolder_visible_idx",
-            ),
-        ),
     ]

--- a/apps/content/migrations/0050_recitationfolder_is_visible.py
+++ b/apps/content/migrations/0050_recitationfolder_is_visible.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("content", "0049_recitation_track_folder_constraints"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="recitationfolder",
+            name="is_visible",
+            field=models.BooleanField(
+                db_index=True,
+                default=True,
+                help_text="When false, the folder is omitted from public/tenant APIs and its timings export is withdrawn.",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="recitationfolder",
+            index=models.Index(
+                condition=models.Q(("is_visible", True)),
+                fields=["asset"],
+                name="content_recitationfolder_visible_idx",
+            ),
+        ),
+    ]

--- a/apps/content/models.py
+++ b/apps/content/models.py
@@ -627,6 +627,11 @@ class RecitationFolder(BaseModel):
         default=False,
         help_text="The folder served when the API caller does not specify one. Exactly one per asset.",
     )
+    is_visible = models.BooleanField(
+        default=True,
+        db_index=True,
+        help_text="When false, the folder is omitted from public/tenant APIs and its timings export is withdrawn.",
+    )
 
     class Meta:
         constraints = [

--- a/apps/content/repositories/recitation_folder.py
+++ b/apps/content/repositories/recitation_folder.py
@@ -56,7 +56,7 @@ class RecitationFolderRepository:
             is_default=is_default,
         )
 
-    def update_folder(self, folder: RecitationFolder, fields: dict[str, str | None]) -> RecitationFolder:
+    def update_folder(self, folder: RecitationFolder, fields: dict[str, str | bool | None]) -> RecitationFolder:
         """Apply field updates to a folder and save it."""
         for field, value in fields.items():
             setattr(folder, field, value)

--- a/apps/content/services/admin/asset_recitation_json_file_sync_service.py
+++ b/apps/content/services/admin/asset_recitation_json_file_sync_service.py
@@ -137,6 +137,4 @@ def unpublish_folder_recitations_json(asset_id: int, folder_id: int) -> None:
         version.size_bytes = 0
         version.save(update_fields=["file_url", "size_bytes", "updated_at"])
 
-    logger.info(
-        f"Recitation JSON unpublished [asset_id={asset_id}, folder_id={folder_id}, version_id={version.pk}]"
-    )
+    logger.info(f"Recitation JSON unpublished [asset_id={asset_id}, folder_id={folder_id}, version_id={version.pk}]")

--- a/apps/content/services/admin/asset_recitation_json_file_sync_service.py
+++ b/apps/content/services/admin/asset_recitation_json_file_sync_service.py
@@ -116,3 +116,27 @@ def sync_asset_recitations_json_file(asset_id: int, folder_id: int | None = None
         f"tracks={track_count}, size_bytes={len(payload_bytes)}, filename={filename}]"
     )
     return version, filename
+
+
+def unpublish_folder_recitations_json(asset_id: int, folder_id: int) -> None:
+    """
+    Withdraw a folder's timings JSON export when the folder is hidden from public APIs.
+
+    The AssetVersion row is kept so a later show + sync can republish under the same slug.
+    """
+    folder: RecitationFolder | None = RecitationFolder.objects.filter(pk=folder_id, asset_id=asset_id).first()
+    if folder is None:
+        return
+
+    version: AssetVersion | None = AssetVersion.objects.filter(asset_id=asset_id, name=folder.slug).first()
+    if version is None or not version.file_url:
+        return
+
+    with transaction.atomic():
+        version.file_url.delete(save=False)
+        version.size_bytes = 0
+        version.save(update_fields=["file_url", "size_bytes", "updated_at"])
+
+    logger.info(
+        f"Recitation JSON unpublished [asset_id={asset_id}, folder_id={folder_id}, version_id={version.pk}]"
+    )

--- a/apps/content/services/admin/asset_recitation_json_file_sync_service.py
+++ b/apps/content/services/admin/asset_recitation_json_file_sync_service.py
@@ -116,25 +116,3 @@ def sync_asset_recitations_json_file(asset_id: int, folder_id: int | None = None
         f"tracks={track_count}, size_bytes={len(payload_bytes)}, filename={filename}]"
     )
     return version, filename
-
-
-def unpublish_folder_recitations_json(asset_id: int, folder_id: int) -> None:
-    """
-    Withdraw a folder's timings JSON export when the folder is hidden from public APIs.
-
-    The AssetVersion row is kept so a later show + sync can republish under the same slug.
-    """
-    folder: RecitationFolder | None = RecitationFolder.objects.filter(pk=folder_id, asset_id=asset_id).first()
-    if folder is None:
-        return
-
-    version: AssetVersion | None = AssetVersion.objects.filter(asset_id=asset_id, name=folder.slug).first()
-    if version is None or not version.file_url:
-        return
-
-    with transaction.atomic():
-        version.file_url.delete(save=False)
-        version.size_bytes = 0
-        version.save(update_fields=["file_url", "size_bytes", "updated_at"])
-
-    logger.info(f"Recitation JSON unpublished [asset_id={asset_id}, folder_id={folder_id}, version_id={version.pk}]")

--- a/apps/content/services/recitation.py
+++ b/apps/content/services/recitation.py
@@ -216,6 +216,7 @@ class RecitationService:
         publisher_q: Q,
         prefetch_timings: bool = False,
         folder: str | None = None,
+        require_visible_folder: bool = False,
     ) -> QuerySet[RecitationSurahTrack]:
         """
         Business Logic: Retrieve tracks for a specific asset if it belongs to the publisher.
@@ -228,7 +229,7 @@ class RecitationService:
         """
         folder_id = None
         if folder is not None:
-            matched = find_folder_by_token(asset_id, folder)
+            matched = find_folder_by_token(asset_id, folder, require_visible=require_visible_folder)
             if matched is None:
                 raise ItqanError(
                     error_name="folder_not_found",

--- a/apps/content/services/recitation_folder.py
+++ b/apps/content/services/recitation_folder.py
@@ -10,10 +10,6 @@ from django.utils.translation import gettext_lazy as _
 from apps.content.cache import invalidate_recitation_folder_cache
 from apps.content.models import RecitationFolder
 from apps.content.repositories.recitation_folder import RecitationFolderRepository
-from apps.content.services.admin.asset_recitation_json_file_sync_service import (
-    sync_asset_recitations_json_file,
-    unpublish_folder_recitations_json,
-)
 from apps.core.ninja_utils.errors import ItqanError
 
 if TYPE_CHECKING:
@@ -153,10 +149,6 @@ class RecitationFolderService:
             folder.save(update_fields=["is_visible", "updated_at"])
 
         if visibility_changed:
-            if folder.is_visible:
-                sync_asset_recitations_json_file(asset_id, folder_id=folder.pk)
-            else:
-                unpublish_folder_recitations_json(asset_id, folder_id=folder.pk)
             invalidate_recitation_folder_cache(asset_id, folder)
 
         if name_fields or visibility_changed:

--- a/apps/content/services/recitation_folder.py
+++ b/apps/content/services/recitation_folder.py
@@ -129,9 +129,7 @@ class RecitationFolderService:
             if is_visible is not None and is_visible != folder.is_visible:
                 folder.is_visible = is_visible
                 visibility_changed = True
-                logger.info(
-                    f"Recitation folder visibility changed [folder_id={folder.pk}, is_visible={is_visible}]"
-                )
+                logger.info(f"Recitation folder visibility changed [folder_id={folder.pk}, is_visible={is_visible}]")
 
         name_fields = {k: v for k, v in fields.items() if k in ("name_ar", "name_en")}
         if name_fields:

--- a/apps/content/services/recitation_folder.py
+++ b/apps/content/services/recitation_folder.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
+from apps.content.cache import invalidate_recitation_folder_cache
 from apps.content.models import RecitationFolder
 from apps.content.repositories.recitation_folder import RecitationFolderRepository
+from apps.content.services.admin.asset_recitation_json_file_sync_service import (
+    sync_asset_recitations_json_file,
+    unpublish_folder_recitations_json,
+)
 from apps.core.ninja_utils.errors import ItqanError
 
 if TYPE_CHECKING:
@@ -47,9 +53,6 @@ class RecitationFolderService:
 
         default_folder = self.repo.get_default_for_asset(asset_id)
         if default_folder is None:
-            # Every recitation gets a default folder at creation, and existing ones
-            # were backfilled, so this means the asset was built outside the service
-            # layer. Surface it rather than silently returning no tracks.
             logger.error(f"Recitation asset has no default folder [asset_id={asset_id}]")
             raise ItqanError(
                 error_name="folder_not_found",
@@ -92,39 +95,97 @@ class RecitationFolderService:
         *,
         asset_id: int,
         folder_slug: str,
-        fields: dict[str, str | None],
+        fields: dict[str, Any],
         publisher_q: Q | None = None,
     ) -> RecitationFolder:
         """
-        Business Logic: rename a folder.
+        Business Logic: update a folder's names, visibility, or default status.
 
         The slug is left alone on rename: it is the public ``?folder=`` value, and
         changing it would break links and cached responses already pointing at it.
         """
         folder = self.get_folder_or_404(asset_id, folder_slug, publisher_q=publisher_q)
 
-        for field in ("name_ar", "name_en"):
-            if field in fields:
-                fields[field] = (fields[field] or "").strip()
+        if "is_default" in fields:
+            is_default = fields.pop("is_default")
+            if is_default is False:
+                raise ItqanError(
+                    error_name="cannot_unset_default_folder",
+                    message=_("Use another folder's set-default action instead of clearing the default flag."),
+                    status_code=400,
+                )
+            if is_default is True:
+                return self._promote_to_default(folder)
 
-        final_name_ar = fields.get("name_ar", folder.name_ar) or ""
-        final_name_en = fields.get("name_en", folder.name_en) or ""
-        if not final_name_ar and not final_name_en:
+        visibility_changed = False
+        if "is_visible" in fields:
+            is_visible = fields.pop("is_visible")
+            if is_visible is False and folder.is_default:
+                raise ItqanError(
+                    error_name="cannot_hide_default_folder",
+                    message=_("The default folder cannot be hidden."),
+                    status_code=400,
+                )
+            if is_visible is not None and is_visible != folder.is_visible:
+                folder.is_visible = is_visible
+                visibility_changed = True
+                logger.info(
+                    f"Recitation folder visibility changed [folder_id={folder.pk}, is_visible={is_visible}]"
+                )
+
+        name_fields = {k: v for k, v in fields.items() if k in ("name_ar", "name_en")}
+        if name_fields:
+            for field in ("name_ar", "name_en"):
+                if field in name_fields:
+                    name_fields[field] = (name_fields[field] or "").strip()
+
+            final_name_ar = name_fields.get("name_ar", folder.name_ar) or ""
+            final_name_en = name_fields.get("name_en", folder.name_en) or ""
+            if not final_name_ar and not final_name_en:
+                raise ItqanError(
+                    error_name="folder_name_required",
+                    message=_("Folder name (Arabic or English) is required."),
+                    status_code=400,
+                )
+
+            ordered_fields: dict[str, str | None] = {"name": final_name_ar or final_name_en}
+            ordered_fields.update(name_fields)
+            folder = self.repo.update_folder(folder, fields=ordered_fields)
+        elif visibility_changed:
+            folder.save(update_fields=["is_visible", "updated_at"])
+
+        if visibility_changed:
+            if folder.is_visible:
+                sync_asset_recitations_json_file(asset_id, folder_id=folder.pk)
+            else:
+                unpublish_folder_recitations_json(asset_id, folder_id=folder.pk)
+            invalidate_recitation_folder_cache(asset_id, folder)
+
+        if name_fields or visibility_changed:
+            logger.info(f"Recitation folder updated [folder_id={folder.pk}, asset_id={asset_id}]")
+        return folder
+
+    def _promote_to_default(self, folder: RecitationFolder) -> RecitationFolder:
+        if folder.is_default:
+            return folder
+
+        if not folder.is_visible:
             raise ItqanError(
-                error_name="folder_name_required",
-                message=_("Folder name (Arabic or English) is required."),
+                error_name="cannot_set_hidden_folder_as_default",
+                message=_("A hidden folder cannot be set as the default."),
                 status_code=400,
             )
 
-        # `name` is a modeltranslation descriptor that writes through to the active
-        # language's column, so it must be applied *before* the explicit name_ar /
-        # name_en values — otherwise it silently overwrites one of them.
-        ordered_fields: dict[str, str | None] = {"name": final_name_ar or final_name_en}
-        ordered_fields.update(fields)
+        with transaction.atomic():
+            RecitationFolder.objects.filter(asset_id=folder.asset_id, is_default=True).update(is_default=False)
+            folder.is_default = True
+            folder.save(update_fields=["is_default", "updated_at"])
 
-        updated = self.repo.update_folder(folder, fields=ordered_fields)
-        logger.info(f"Recitation folder updated [folder_id={updated.pk}, asset_id={asset_id}]")
-        return updated
+        logger.info(
+            f"Recitation folder promoted to default [folder_id={folder.pk}, asset_id={folder.asset_id}, slug={folder.slug}]"
+        )
+        invalidate_recitation_folder_cache(folder.asset_id, folder)
+        return folder
 
     def delete_folder(self, *, asset_id: int, folder_slug: str, publisher_q: Q | None = None) -> None:
         """
@@ -142,5 +203,7 @@ class RecitationFolderService:
                 status_code=400,
             )
 
+        asset_id = folder.asset_id
         self.repo.delete_folder(folder)
+        invalidate_recitation_folder_cache(asset_id, folder)
         logger.info(f"Recitation folder deleted [asset_id={asset_id}, slug={folder_slug}]")

--- a/apps/content/services/recitation_folder_resolution.py
+++ b/apps/content/services/recitation_folder_resolution.py
@@ -23,7 +23,15 @@ def sorted_asset_folders(asset: Asset) -> list[RecitationFolder]:
     return sorted(asset.recitation_folders.all(), key=lambda f: (not f.is_default, f.name or ""))
 
 
-def find_folder_by_token(asset_id: int, token: str) -> RecitationFolder | None:
+def visible_asset_folders(asset: Asset) -> list[RecitationFolder]:
+    """Public/tenant list shape: visible folders only, same sort as ``sorted_asset_folders``."""
+    return sorted(
+        (f for f in asset.recitation_folders.all() if f.is_visible),
+        key=lambda f: (not f.is_default, f.name or ""),
+    )
+
+
+def find_folder_by_token(asset_id: int, token: str, *, require_visible: bool = False) -> RecitationFolder | None:
     """
     Resolve a user-supplied ``?folder=`` value, which may be a slug **or** a folder name.
 
@@ -37,18 +45,26 @@ def find_folder_by_token(asset_id: int, token: str) -> RecitationFolder | None:
     default one when present and otherwise the oldest. That is deterministic rather
     than arbitrary; callers wanting an exact target should pass the slug.
 
+    When ``require_visible`` is True (public/tenant reads), hidden folders resolve as
+    not found so callers can raise ``folder_not_found``.
+
     Returns None when nothing matches, so the caller can raise ``folder_not_found``.
     """
     by_slug = RecitationFolder.objects.filter(asset_id=asset_id, slug=token).first()
     if by_slug is not None:
+        if require_visible and not by_slug.is_visible:
+            return None
         return by_slug
 
-    return (
+    matched = (
         RecitationFolder.objects.filter(asset_id=asset_id)
         .filter(Q(name__iexact=token) | Q(name_ar__iexact=token) | Q(name_en__iexact=token))
         .order_by("-is_default", "id")
         .first()
     )
+    if matched is not None and require_visible and not matched.is_visible:
+        return None
+    return matched
 
 
 def resolve_folder_for_asset(asset_id: int, folder_id: int | None) -> RecitationFolder:

--- a/apps/content/tests/portal/recitations/test_recitation_folders.py
+++ b/apps/content/tests/portal/recitations/test_recitation_folders.py
@@ -202,6 +202,45 @@ class RecitationFoldersPortalAPITest(BaseTestCase):
         self.assertEqual(403, response.status_code, response.content)
         self.assertEqual("permission_denied", response.json()["error_name"])
 
+    def test_update_folder_where_hidden_should_return_200_with_is_visible(self):
+        self.authenticate_user(self.staff_user)
+        self.give_permission(self.staff_user, PermissionChoice.PORTAL_UPDATE_RECITATION)
+        echo = RecitationFolder.objects.create(asset=self.asset, name="With echo", name_en="With echo")
+
+        response = self.client.patch(f"{self.url}with-echo/", {"is_visible": False}, format="json")
+
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertFalse(response.json()["is_visible"])
+        echo.refresh_from_db()
+        self.assertFalse(echo.is_visible)
+
+    def test_update_folder_where_default_hidden_should_return_400(self):
+        self.authenticate_user(self.staff_user)
+        self.give_permission(self.staff_user, PermissionChoice.PORTAL_UPDATE_RECITATION)
+
+        response = self.client.patch(
+            f"{self.url}{self.default_folder.slug}/",
+            {"is_visible": False},
+            format="json",
+        )
+
+        self.assertEqual(400, response.status_code, response.content)
+        self.assertEqual("cannot_hide_default_folder", response.json()["error_name"])
+
+    def test_update_folder_where_set_default_should_promote_variant(self):
+        self.authenticate_user(self.staff_user)
+        self.give_permission(self.staff_user, PermissionChoice.PORTAL_UPDATE_RECITATION)
+        echo = RecitationFolder.objects.create(asset=self.asset, name="With echo", name_en="With echo")
+
+        response = self.client.patch(f"{self.url}with-echo/", {"is_default": True}, format="json")
+
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertTrue(response.json()["is_default"])
+        self.default_folder.refresh_from_db()
+        echo.refresh_from_db()
+        self.assertFalse(self.default_folder.is_default)
+        self.assertTrue(echo.is_default)
+
 
 class RecitationFoldersPortalScopingTest(BaseTestCase):
     """Folders must never be reachable through another publisher's recitation."""

--- a/apps/content/tests/public/test_recitation_folder_filtering.py
+++ b/apps/content/tests/public/test_recitation_folder_filtering.py
@@ -342,3 +342,27 @@ class PublicRecitationFolderFilteringTest(BaseTestCase):
         # Assert
         self.assertEqual(0, default_items[0]["ayahs_timings"][0]["start_ms"])
         self.assertEqual(250, echo_items[0]["ayahs_timings"][0]["start_ms"])
+
+    def test_list_recitations_should_omit_hidden_folders(self):
+        self.echo_folder.is_visible = False
+        self.echo_folder.save(update_fields=["is_visible"])
+        self.authenticate_client(self.app)
+
+        response = self.client.get("/recitations/")
+
+        self.assertEqual(200, response.status_code, response.content)
+        recitation = next(r for r in response.json()["results"] if r["id"] == self.asset.id)
+        self.assertEqual(
+            [{"name": "Default", "slug": "default", "is_default": True}],
+            recitation["folders"],
+        )
+
+    def test_list_tracks_where_folder_hidden_should_return_404(self):
+        self.echo_folder.is_visible = False
+        self.echo_folder.save(update_fields=["is_visible"])
+        self.authenticate_client(self.app)
+
+        response = self.client.get(f"/recitations/{self.asset.id}/?folder=with-echo")
+
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("folder_not_found", response.json()["error_name"])

--- a/apps/content/tests/services/test_recitation_folder_service.py
+++ b/apps/content/tests/services/test_recitation_folder_service.py
@@ -231,6 +231,74 @@ class FindFolderByTokenTest(BaseTestCase):
         self.assertEqual(found.id, self.echo.id)
 
 
+class RecitationFolderVisibilityTest(BaseTestCase):
+    def setUp(self) -> None:
+        self.asset = make_recitation_asset()
+        self.default_folder = RecitationFolder.objects.get(asset=self.asset, is_default=True)
+        RecitationFolder.objects.create(asset=self.asset, name="With echo", name_en="With echo")
+        self.service = RecitationFolderService()
+
+    def test_hide_variant_should_set_is_visible_false(self):
+        updated = self.service.update_folder(
+            asset_id=self.asset.id,
+            folder_slug="with-echo",
+            fields={"is_visible": False},
+        )
+        self.assertFalse(updated.is_visible)
+
+    def test_hide_default_should_raise_cannot_hide_default_folder(self):
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.update_folder(
+                asset_id=self.asset.id,
+                folder_slug=RecitationFolder.DEFAULT_SLUG,
+                fields={"is_visible": False},
+            )
+        self.assertEqual(ctx.exception.error_name, "cannot_hide_default_folder")
+
+    def test_promote_variant_should_swap_default_flag(self):
+        promoted = self.service.update_folder(
+            asset_id=self.asset.id,
+            folder_slug="with-echo",
+            fields={"is_default": True},
+        )
+        self.default_folder.refresh_from_db()
+        self.assertTrue(promoted.is_default)
+        self.assertFalse(self.default_folder.is_default)
+
+    def test_promote_hidden_folder_should_raise_cannot_set_hidden_folder_as_default(self):
+        echo = RecitationFolder.objects.get(asset=self.asset, slug="with-echo")
+        echo.is_visible = False
+        echo.save(update_fields=["is_visible"])
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.update_folder(
+                asset_id=self.asset.id,
+                folder_slug="with-echo",
+                fields={"is_default": True},
+            )
+        self.assertEqual(ctx.exception.error_name, "cannot_set_hidden_folder_as_default")
+
+    def test_unset_default_flag_should_raise_cannot_unset_default_folder(self):
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.update_folder(
+                asset_id=self.asset.id,
+                folder_slug=RecitationFolder.DEFAULT_SLUG,
+                fields={"is_default": False},
+            )
+        self.assertEqual(ctx.exception.error_name, "cannot_unset_default_folder")
+
+
+class FindFolderVisibilityTest(BaseTestCase):
+    def setUp(self) -> None:
+        self.asset = make_recitation_asset()
+        self.echo = RecitationFolder.objects.create(asset=self.asset, name="With echo", name_en="With echo")
+
+    def test_find_folder_where_hidden_and_require_visible_should_return_none(self):
+        self.echo.is_visible = False
+        self.echo.save(update_fields=["is_visible"])
+        self.assertIsNone(find_folder_by_token(self.asset.id, "with-echo", require_visible=True))
+        self.assertIsNotNone(find_folder_by_token(self.asset.id, "with-echo", require_visible=False))
+
+
 class RecitationServiceFolderScopingTest(BaseTestCase):
     def setUp(self) -> None:
         self.asset = make_recitation_asset()
@@ -293,6 +361,18 @@ class RecitationServiceFolderScopingTest(BaseTestCase):
 
         # Assert - 2 default tracks + 1 echo track must not report 3 surahs
         self.assertEqual(recitation.surahs_count, 2)
+
+    def test_get_asset_tracks_where_folder_hidden_should_raise_folder_not_found(self):
+        self.echo_folder.is_visible = False
+        self.echo_folder.save(update_fields=["is_visible"])
+        with self.assertRaises(ItqanError) as ctx:
+            self.service.get_asset_tracks(
+                self.asset.id,
+                publisher_q=None,
+                folder="with-echo",
+                require_visible_folder=True,
+            )
+        self.assertEqual(ctx.exception.error_name, "folder_not_found")
 
 
 class RecitationCreationDefaultFolderTest(BaseTestCase):

--- a/apps/content/tests/tenant/test_recitation_folder_filtering.py
+++ b/apps/content/tests/tenant/test_recitation_folder_filtering.py
@@ -1,0 +1,95 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from model_bakery import baker
+
+from apps.content.models import (
+    Asset,
+    CategoryChoice,
+    RecitationFolder,
+    RecitationSurahTrack,
+    StatusChoice,
+)
+from apps.core.tests.base import BaseTestCase
+from apps.publishers.models import Publisher
+from apps.users.models import User
+
+
+class TenantRecitationFolderFilteringTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.publisher = baker.make(Publisher)
+        self.domain = baker.make(
+            "publishers.Domain",
+            domain="tenant-folders.com",
+            publisher=self.publisher,
+            is_primary=True,
+        )
+        self.asset = baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            publisher=self.publisher,
+            status=StatusChoice.READY,
+            reciter=baker.make("content.Reciter", name="Tenant Reciter"),
+            riwayah=baker.make("content.Riwayah", name="Tenant Riwayah"),
+        )
+        self.default_folder = self.asset.recitation_folders.get(is_default=True)
+        self.echo_folder = RecitationFolder.objects.create(asset=self.asset, name="With echo", name_en="With echo")
+
+        for surah_number in (1, 2):
+            RecitationSurahTrack.objects.create(
+                asset=self.asset,
+                folder=self.default_folder,
+                surah_number=surah_number,
+                duration_ms=1000,
+                size_bytes=512,
+                audio_file=SimpleUploadedFile(f"{surah_number:03}.mp3", b"dummy"),
+            )
+        RecitationSurahTrack.objects.create(
+            asset=self.asset,
+            folder=self.echo_folder,
+            surah_number=1,
+            duration_ms=9999,
+            size_bytes=4096,
+            audio_file=SimpleUploadedFile("001-echo.mp3", b"dummy"),
+        )
+
+        self.user = User.objects.create_user(email="tenant-folders@example.com", name="Tenant User")
+
+    def test_list_recitations_should_omit_hidden_folders(self):
+        self.echo_folder.is_visible = False
+        self.echo_folder.save(update_fields=["is_visible"])
+        self.authenticate_user(self.user, domain=self.domain)
+
+        response = self.client.get("/tenant/recitations/", format="json")
+
+        self.assertEqual(200, response.status_code, response.content)
+        recitation = next(r for r in response.json()["results"] if r["id"] == self.asset.id)
+        self.assertEqual(
+            [{"name": "Default", "slug": "default", "is_default": True}],
+            recitation["folders"],
+        )
+
+    def test_list_tracks_where_folder_hidden_should_return_404(self):
+        self.echo_folder.is_visible = False
+        self.echo_folder.save(update_fields=["is_visible"])
+        self.authenticate_user(self.user, domain=self.domain)
+
+        response = self.client.get(f"/tenant/recitation-tracks/{self.asset.id}/?folder=with-echo", format="json")
+
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("folder_not_found", response.json()["error_name"])
+
+    def test_list_tracks_where_default_promoted_should_return_new_default_without_folder_param(self):
+        self.echo_folder.is_default = True
+        self.default_folder.is_default = False
+        RecitationFolder.objects.bulk_update(
+            [self.echo_folder, self.default_folder],
+            ["is_default"],
+        )
+        self.authenticate_user(self.user, domain=self.domain)
+
+        response = self.client.get(f"/tenant/recitation-tracks/{self.asset.id}/", format="json")
+
+        self.assertEqual(200, response.status_code, response.content)
+        items = response.json()["results"]
+        self.assertEqual(1, len(items))
+        self.assertEqual(9999, items[0]["duration_ms"])

--- a/apps/content/tests/tenant/test_recitation_folder_filtering.py
+++ b/apps/content/tests/tenant/test_recitation_folder_filtering.py
@@ -1,13 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from model_bakery import baker
 
-from apps.content.models import (
-    Asset,
-    CategoryChoice,
-    RecitationFolder,
-    RecitationSurahTrack,
-    StatusChoice,
-)
+from apps.content.models import Asset, CategoryChoice, RecitationFolder, RecitationSurahTrack, StatusChoice
 from apps.core.tests.base import BaseTestCase
 from apps.publishers.models import Publisher
 from apps.users.models import User

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <h.alansary@itqan.dev>, 2026.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <h.alansary@itqan.dev>, 2026.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -349,6 +349,15 @@ msgstr "لا يحتوي هذا التسجيل على مجلد افتراضي."
 
 msgid "Folder name (Arabic or English) is required."
 msgstr "اسم المجلد (بالعربية أو الإنجليزية) مطلوب."
+
+msgid "Use another folder's set-default action instead of clearing the default flag."
+msgstr "استخدم إجراء تعيين الافتراضي لمجلد آخر بدلاً من إلغاء علامة الافتراضي."
+
+msgid "The default folder cannot be hidden."
+msgstr "لا يمكن إخفاء المجلد الافتراضي."
+
+msgid "A hidden folder cannot be set as the default."
+msgstr "لا يمكن تعيين مجلد مخفي كمجلد افتراضي."
 
 msgid "The default folder cannot be deleted."
 msgstr "لا يمكن حذف المجلد الافتراضي."


### PR DESCRIPTION
Add is_visible with public/tenant filtering, timings unpublish on hide, and PATCH is_default to promote a visible variant without changing slugs.