### PR TITLE
feat(content): public api to serve single-ayah recitation audio (#414)

### DIFF
--- a/apps/content/api/public/recitation_ayah.py
+++ b/apps/content/api/public/recitation_ayah.py
@@ -57,6 +57,9 @@ def get_recitation_ayah(
     """
     Public developers API endpoint to return audio URL and metadata for a single Ayah.
     """
+    # Key on the requested folder token rather than the resolved folder: resolving it
+    # requires a DB read before the cache lookup, defeating the warm-cache zero-query
+    # guarantee. Matches the established pattern in recitation_track_list.
     token = folder_cache_token(folder)
     _resp_key = recitation_ayah_response_cache_key(asset_id, token, ayah_key)
     _meta_key = recitation_asset_meta_cache_key(asset_id)

--- a/apps/content/api/public/recitation_ayah.py
+++ b/apps/content/api/public/recitation_ayah.py
@@ -1,0 +1,143 @@
+import json
+from typing import Literal
+
+from django.core.cache import cache
+from django.db.models import Q
+from django.http import HttpResponse
+from ninja import Query, Schema
+
+from apps.content.cache import (
+    RECITATION_ASSET_META_CACHE_TTL,
+    RECITATION_AYAH_RESPONSE_CACHE_TTL,
+    folder_cache_token,
+    recitation_asset_meta_cache_key,
+    recitation_ayah_response_cache_key,
+)
+from apps.content.repositories.recitation import RecitationRepository
+from apps.content.services.asset_access import enforce_asset_access_on_public_api
+from apps.content.services.recitation import RecitationService
+from apps.core.ninja_utils.errors import NinjaErrorResponse
+from apps.core.ninja_utils.request import Request
+from apps.core.ninja_utils.router import ItqanRouter
+from apps.core.ninja_utils.tags import NinjaTag
+from apps.usage_tracking.decorators.track_usage import track_extra, track_usage
+
+router = ItqanRouter(tags=[NinjaTag.RECITATIONS])
+
+
+class RecitationAyahAudioOut(Schema):
+    """Output schema representing an individual Ayah audio track and its playback metadata."""
+
+    ayah_key: str
+    surah_number: int
+    ayah_number: int
+    duration_ms: int
+    size_bytes: int | None = None
+    audio_url: str
+
+
+@router.get(
+    "recitations/{asset_id}/ayah/{ayah_key}/",
+    response={
+        200: RecitationAyahAudioOut,
+        401: NinjaErrorResponse[Literal["authentication_required"]],
+        403: NinjaErrorResponse[Literal["access_denied"]],
+        404: NinjaErrorResponse[Literal["asset_not_found"]]
+        | NinjaErrorResponse[Literal["folder_not_found"]]
+        | NinjaErrorResponse[Literal["ayah_not_found"]],
+    },
+)
+@track_usage(entity_type="recitation")
+def get_recitation_ayah(
+    request: Request,
+    asset_id: int,
+    ayah_key: str,
+    folder: str | None = Query(None),
+):
+    """
+    Public developers API endpoint to return audio URL and metadata for a single Ayah.
+    """
+    token = folder_cache_token(folder)
+    _resp_key = recitation_ayah_response_cache_key(asset_id, token, ayah_key)
+    _meta_key = recitation_asset_meta_cache_key(asset_id)
+
+    cached_resp: bytes | None = cache.get(_resp_key)
+    cached_meta: dict | None = cache.get(_meta_key)
+
+    if cached_resp is not None and cached_meta is not None and "is_open_access" in cached_meta:
+        is_open_access: bool = cached_meta["is_open_access"]
+        if not is_open_access:
+            enforce_asset_access_on_public_api(
+                getattr(request, "user", None),
+                asset_id=asset_id,
+                is_open_access=is_open_access,
+            )
+
+        track_extra(
+            request,
+            entity_type="recitation",
+            accessed_entity_name=cached_meta["name_ar"],
+            entity_ids=[asset_id],
+            entity_names=[cached_meta["name_ar"]],
+            publisher_ids=[cached_meta["publisher_id"]] if cached_meta["publisher_id"] else [],
+            publisher_names=[cached_meta["publisher_name"]] if cached_meta["publisher_id"] else [],
+            folder=folder,
+            ayah_key=ayah_key,
+        )
+        resp = HttpResponse(cached_resp, content_type="application/json")
+        resp["Cache-Control"] = "public, max-age=300, s-maxage=300" if is_open_access else "private, no-cache"
+        return resp
+
+    # Cache miss - query service & repository
+    repo = RecitationRepository()
+    service = RecitationService(repo)
+
+    data = service.get_ayah_audio_data(
+        asset_id=asset_id,
+        ayah_key=ayah_key,
+        folder=folder,
+        publisher_q=Q(restricted_for_tenant=False),
+        require_visible_folder=True,
+    )
+
+    asset = data["asset"]
+    enforce_asset_access_on_public_api(getattr(request, "user", None), asset)
+
+    publisher_name = asset.publisher.name if asset.publisher_id else None
+    asset_meta = {
+        "name_ar": asset.name_ar,
+        "publisher_id": asset.publisher_id,
+        "publisher_name": publisher_name,
+        "is_open_access": asset.is_open_access,
+    }
+
+    track_extra(
+        request,
+        entity_type="recitation",
+        accessed_entity_name=asset.name_ar,
+        entity_ids=[asset.id],
+        entity_names=[asset.name_ar],
+        publisher_ids=[asset.publisher_id] if asset.publisher_id else [],
+        publisher_names=[publisher_name] if asset.publisher_id else [],
+        folder=folder,
+        ayah_key=data["ayah_key"],
+    )
+
+    result_payload = {
+        "ayah_key": data["ayah_key"],
+        "surah_number": data["surah_number"],
+        "ayah_number": data["ayah_number"],
+        "duration_ms": data["duration_ms"],
+        "size_bytes": data["size_bytes"],
+        "audio_url": data["audio_url"],
+    }
+
+    serialized_out = RecitationAyahAudioOut(**result_payload).model_dump()
+    response_bytes = json.dumps(serialized_out).encode("utf-8")
+
+    cache.set(_resp_key, response_bytes, RECITATION_AYAH_RESPONSE_CACHE_TTL)
+    cache.set(_meta_key, asset_meta, RECITATION_ASSET_META_CACHE_TTL)
+
+    resp = HttpResponse(response_bytes, content_type="application/json")
+    resp["Cache-Control"] = "public, max-age=300, s-maxage=300" if asset.is_open_access else "private, no-cache"
+    return resp

--- a/apps/content/cache.py
+++ b/apps/content/cache.py
@@ -15,6 +15,7 @@ _SAFE_CACHE_TOKEN_RE = re.compile(r"^[a-z0-9_.-]{1,64}$")
 RECITATION_TRACKS_CACHE_TTL = 60 * 5  # 5 minutes
 RECITATION_ASSET_META_CACHE_TTL = 60 * 60  # 1 hour - asset name/publisher rarely changes
 RECITATION_RESPONSE_CACHE_TTL = 60 * 5  # 5 minutes
+RECITATION_AYAH_RESPONSE_CACHE_TTL = 60 * 5  # 5 minutes
 
 
 def recitation_tracks_cache_key(asset_id: int) -> str:
@@ -51,6 +52,11 @@ def recitation_response_cache_key(asset_id: int, page: int, page_size: int, fold
     # The folder is part of the key: two variants of the same recitation share an
     # asset_id, so omitting it would serve one variant's audio for the other.
     return f"public_recitation_resp:{asset_id}:{folder_slug}:{page}:{page_size}"
+
+
+def recitation_ayah_response_cache_key(asset_id: int, folder_token: str, ayah_key: str) -> str:
+    """Build the Redis cache key for a single ayah audio public response."""
+    return f"public_recitation_ayah_resp:{asset_id}:{folder_token}:{ayah_key}"
 
 
 def invalidate_recitation_tracks_cache(asset_id: int) -> None:

--- a/apps/content/repositories/recitation.py
+++ b/apps/content/repositories/recitation.py
@@ -30,6 +30,7 @@ class RecitationRepository(BaseRecitationRepository):
         self.track_model = RecitationSurahTrack
         self.riwayah_model = Riwayah
         self.qiraah_model = Qiraah
+        self.timing_model = RecitationAyahTiming
 
     def list_recitations_qs(
         self, publisher_q: Q | None, filters_dict: dict[str, Any], annotate_surahs_count: bool = False
@@ -419,3 +420,18 @@ class RecitationRepository(BaseRecitationRepository):
                 qs = qs.filter(slug__icontains=slug)
 
         return qs
+
+    def get_ayah_timing_for_asset(
+        self, asset_id: int, folder_id: int, surah_number: int, ayah_key: str
+    ) -> RecitationAyahTiming | None:
+        """Fetch the timing record for a specific ayah scoped by asset, folder, and surah."""
+        return (
+            self.timing_model.objects.select_related("track", "track__asset", "track__folder")
+            .filter(
+                track__asset_id=asset_id,
+                track__folder_id=folder_id,
+                track__surah_number=surah_number,
+                ayah_key=ayah_key,
+            )
+            .first()
+        )

--- a/apps/content/services/recitation.py
+++ b/apps/content/services/recitation.py
@@ -359,6 +359,10 @@ class RecitationService:
                 status_code=404,
             )
 
+        # Media URL generation: Follows the project-wide storage architecture
+        # (MediaFileStorage / CLOUDFLARE_R2_PUBLIC_BASE_URL). Access control is enforced
+        # at the API gateway layer via enforce_asset_access_on_public_api before this URL
+        # is returned to consumers, matching recitation_track_list and samples endpoints.
         base_url = getattr(settings, "CLOUDFLARE_R2_PUBLIC_BASE_URL", CLOUDFLARE_R2_PUBLIC_BASE_URL).rstrip("/")
         slice_key = f"uploads/assets/{asset_id}/recitations/{folder_obj.id}/{surah_number:03}/ayah_{ayah_number:03}.mp3"
         audio_url = f"{base_url}/media/{slice_key}"

--- a/apps/content/services/recitation.py
+++ b/apps/content/services/recitation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.conf import settings
 from django.db.models import ProtectedError, Q, QuerySet
 from django.utils.translation import gettext as _
 
@@ -12,6 +13,7 @@ from apps.content.services.asset_access import guard_restrict_for_tenant
 from apps.content.services.recitation_folder_resolution import find_folder_by_token
 from apps.core.ninja_utils.errors import ItqanError
 from apps.publishers.models import Publisher
+from config.settings.base import CLOUDFLARE_R2_PUBLIC_BASE_URL
 
 logger = logging.getLogger(__name__)
 
@@ -268,3 +270,111 @@ class RecitationService:
         sample recitation, with ayah timings prefetched in playback order.
         """
         return self.repo.get_default_track_for_surah(asset_id, surah_number)
+
+    def get_ayah_audio_data(
+        self,
+        asset_id: int,
+        ayah_key: str,
+        folder: str | None = None,
+        publisher_q: Q | None = None,
+        require_visible_folder: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Business Logic: Retrieve audio URL and metadata for a single ayah of an asset.
+
+        Args:
+            asset_id: The ID of the asset.
+            ayah_key: Canonical ayah identifier (e.g. '2:255').
+            folder: Optional folder slug or name variant.
+            publisher_q: Optional publisher access constraint filter.
+            require_visible_folder: When True, rejects hidden folders (is_visible=False).
+
+        Returns:
+            Dict containing asset, folder, timing metadata, and Cloudflare R2 audio URL.
+        """
+        parts = ayah_key.strip().split(":")
+        if len(parts) != 2:
+            raise ItqanError(
+                error_name="ayah_not_found",
+                message=_("Ayah {ayah_key} not found.").format(ayah_key=ayah_key),
+                status_code=404,
+            )
+
+        try:
+            surah_number = int(parts[0])
+            ayah_number = int(parts[1])
+        except ValueError as exc:
+            raise ItqanError(
+                error_name="ayah_not_found",
+                message=_("Ayah {ayah_key} not found.").format(ayah_key=ayah_key),
+                status_code=404,
+            ) from exc
+
+        if not (1 <= surah_number <= 114) or ayah_number < 1:
+            raise ItqanError(
+                error_name="ayah_not_found",
+                message=_("Ayah {ayah_key} not found.").format(ayah_key=ayah_key),
+                status_code=404,
+            )
+
+        asset = self.repo.get_asset_object(asset_id, publisher_q=publisher_q)
+        if asset is None:
+            raise ItqanError(
+                error_name="asset_not_found",
+                message=_("Asset with id {id} not found.").format(id=asset_id),
+                status_code=404,
+            )
+
+        if folder is not None:
+            folder_obj = find_folder_by_token(asset_id, folder, require_visible=require_visible_folder)
+            if folder_obj is None:
+                raise ItqanError(
+                    error_name="folder_not_found",
+                    message=_("Folder {folder} not found.").format(folder=folder),
+                    status_code=404,
+                )
+        else:
+            default_qs = asset.recitation_folders.filter(is_default=True)
+            if require_visible_folder:
+                default_qs = default_qs.filter(is_visible=True)
+            folder_obj = default_qs.first()
+            if folder_obj is None:
+                raise ItqanError(
+                    error_name="folder_not_found",
+                    message=_("Default folder for asset {id} not found.").format(id=asset_id),
+                    status_code=404,
+                )
+
+        normalized_ayah_key = f"{surah_number}:{ayah_number}"
+        timing = self.repo.get_ayah_timing_for_asset(
+            asset_id=asset_id,
+            folder_id=folder_obj.id,
+            surah_number=surah_number,
+            ayah_key=normalized_ayah_key,
+        )
+        if timing is None:
+            raise ItqanError(
+                error_name="ayah_not_found",
+                message=_("Ayah {ayah_key} not found.").format(ayah_key=ayah_key),
+                status_code=404,
+            )
+
+        base_url = getattr(settings, "CLOUDFLARE_R2_PUBLIC_BASE_URL", CLOUDFLARE_R2_PUBLIC_BASE_URL).rstrip("/")
+        slice_key = f"uploads/assets/{asset_id}/recitations/{folder_obj.id}/{surah_number:03}/ayah_{ayah_number:03}.mp3"
+        audio_url = f"{base_url}/media/{slice_key}"
+
+        size_bytes: int | None = None
+        track = timing.track
+        if track and track.duration_ms and track.size_bytes:
+            size_bytes = int(track.size_bytes * timing.duration_ms // track.duration_ms)
+
+        return {
+            "asset": asset,
+            "folder": folder_obj,
+            "surah_number": surah_number,
+            "ayah_number": ayah_number,
+            "ayah_key": normalized_ayah_key,
+            "duration_ms": timing.duration_ms,
+            "size_bytes": size_bytes,
+            "audio_url": audio_url,
+        }

--- a/apps/content/signals.py
+++ b/apps/content/signals.py
@@ -12,6 +12,13 @@ def clear_recitation_tracks_cache(sender, instance: RecitationSurahTrack, **kwar
 
 
 @receiver(post_save, sender=Asset)
+def clear_asset_recitation_cache_on_save(sender, instance: Asset, created: bool, **kwargs) -> None:
+    """Invalidate public recitation cache when an asset's metadata or visibility changes."""
+    if not created and instance.category == CategoryChoice.RECITATION:
+        invalidate_recitation_tracks_cache(instance.id)
+
+
+@receiver(post_save, sender=Asset)
 def create_default_recitation_folder(sender, instance: Asset, created: bool, **kwargs) -> None:
     """
     Give every new recitation Asset its default folder.

--- a/apps/content/tests/public/test_recitation_ayah.py
+++ b/apps/content/tests/public/test_recitation_ayah.py
@@ -1,0 +1,296 @@
+import json
+
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from model_bakery import baker
+
+from apps.content.cache import DEFAULT_FOLDER_CACHE_TOKEN, recitation_ayah_response_cache_key
+from apps.content.models import (
+    Asset,
+    AssetAccess,
+    AssetAccessRequest,
+    CategoryChoice,
+    RecitationAyahTiming,
+    RecitationFolder,
+    RecitationSurahTrack,
+    StatusChoice,
+)
+from apps.core.tests.base import BaseTestCase
+from apps.publishers.models import Publisher
+from apps.users.models import APIKey, User
+
+
+class RecitationAyahAudioPublicApiTest(BaseTestCase):
+    """Test suite for single-ayah recitation audio public API endpoint."""
+
+    def setUp(self):
+        """Set up test fixtures for asset, track, timings, and developer credentials."""
+        super().setUp()
+        cache.clear()
+        self.publisher = baker.make(Publisher)
+        self.asset = baker.make(
+            Asset,
+            category=CategoryChoice.RECITATION,
+            publisher=self.publisher,
+            status=StatusChoice.READY,
+            is_open_access=True,
+            restricted_for_tenant=False,
+            reciter=baker.make("content.Reciter", name="Test Reciter"),
+            riwayah=baker.make("content.Riwayah", name="Test Riwayah"),
+        )
+        self.default_folder = self.asset.recitation_folders.get(is_default=True)
+        self.track = baker.make(
+            RecitationSurahTrack,
+            asset=self.asset,
+            folder=self.default_folder,
+            surah_number=2,
+            duration_ms=40000,
+            size_bytes=640000,
+            audio_file=SimpleUploadedFile("s002.mp3", b"dummy-track-content"),
+        )
+        self.timing = baker.make(
+            RecitationAyahTiming,
+            track=self.track,
+            ayah_key="2:255",
+            start_ms=10000,
+            end_ms=25000,
+            duration_ms=15000,
+        )
+        self.user = User.objects.create_user(email="dev@example.com", name="Developer User")
+
+    def _authenticate_with_api_key(self, user: User) -> None:
+        """Helper to create and attach an API key to the test client."""
+        _, raw_key = APIKey.objects.create_key(name="test-key", user=user)
+        self.client.credentials(HTTP_X_API_KEY=raw_key)
+
+    def _grant_access(self, user: User, asset: Asset) -> AssetAccess:
+        """Helper to grant approved access for a developer user to a private asset."""
+        req = baker.make(
+            AssetAccessRequest,
+            developer_user=user,
+            asset=asset,
+            status=AssetAccessRequest.StatusChoice.APPROVED,
+        )
+        return baker.make(AssetAccess, asset_access_request=req, user=user, asset=asset, expires_at=None)
+
+    def test_get_ayah_audio_where_valid_request_should_return_200_and_audio_metadata(self):
+        """Verify that a valid ayah request returns 200 with timing, size, and audio URL."""
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        self.assertEqual("2:255", data["ayah_key"])
+        self.assertEqual(2, data["surah_number"])
+        self.assertEqual(255, data["ayah_number"])
+        self.assertEqual(15000, data["duration_ms"])
+        # Estimated size: 640000 * 15000 // 40000 = 240000
+        self.assertEqual(240000, data["size_bytes"])
+        expected_suffix = f"uploads/assets/{self.asset.id}/recitations/{self.default_folder.id}/002/ayah_255.mp3"
+        self.assertTrue(data["audio_url"].endswith(expected_suffix))
+        self.assertEqual("public, max-age=300, s-maxage=300", response.headers.get("Cache-Control"))
+
+    def test_get_ayah_audio_where_folder_param_provided_should_resolve_variant_folder(self):
+        """Verify that passing folder parameter resolves the variant folder's audio slice."""
+        # Arrange - variant folder
+        echo_folder = baker.make(
+            RecitationFolder,
+            asset=self.asset,
+            name="With Echo",
+            name_en="With Echo",
+            slug="with-echo",
+            is_default=False,
+            is_visible=True,
+        )
+        echo_track = baker.make(
+            RecitationSurahTrack,
+            asset=self.asset,
+            folder=echo_folder,
+            surah_number=2,
+            duration_ms=42000,
+            size_bytes=650000,
+            audio_file=SimpleUploadedFile("echo_s002.mp3", b"dummy-echo-track"),
+        )
+        baker.make(
+            RecitationAyahTiming,
+            track=echo_track,
+            ayah_key="2:255",
+            start_ms=11000,
+            end_ms=27000,
+            duration_ms=16000,
+        )
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/?folder=with-echo")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        data = response.json()
+        expected_suffix = f"uploads/assets/{self.asset.id}/recitations/{echo_folder.id}/002/ayah_255.mp3"
+        self.assertTrue(data["audio_url"].endswith(expected_suffix))
+        self.assertEqual(16000, data["duration_ms"])
+
+    def test_get_ayah_audio_where_folder_not_found_should_return_404_folder_not_found(self):
+        """Verify that requesting an unresolvable folder returns 404 folder_not_found."""
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/?folder=nonexistent-folder")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("folder_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_variant_folder_is_hidden_should_return_404_folder_not_found(self):
+        """Verify that requesting a hidden variant folder returns 404 folder_not_found."""
+        # Arrange - hidden variant folder
+        hidden_folder = baker.make(
+            RecitationFolder,
+            asset=self.asset,
+            name="Hidden Variant",
+            name_en="Hidden Variant",
+            slug="hidden-variant",
+            is_default=False,
+            is_visible=False,
+        )
+        hidden_track = baker.make(
+            RecitationSurahTrack,
+            asset=self.asset,
+            folder=hidden_folder,
+            surah_number=2,
+            duration_ms=40000,
+            size_bytes=640000,
+        )
+        baker.make(
+            RecitationAyahTiming,
+            track=hidden_track,
+            ayah_key="2:255",
+            start_ms=10000,
+            end_ms=25000,
+            duration_ms=15000,
+        )
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/?folder=hidden-variant")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("folder_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_default_folder_is_hidden_should_return_404_folder_not_found(self):
+        """Verify that requesting default ayah audio when the default folder is hidden returns 404."""
+        # Arrange
+        self.default_folder.is_visible = False
+        self.default_folder.save(update_fields=["is_visible"])
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("folder_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_asset_not_found_should_return_404_asset_not_found(self):
+        """Verify that requesting a non-existent asset ID returns 404 asset_not_found."""
+        # Act
+        response = self.client.get("/recitations/999999/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("asset_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_ayah_not_found_should_return_404_ayah_not_found(self):
+        """Verify that requesting an ayah that has no timing record returns 404 ayah_not_found."""
+        # Act - Surah 2 Ayah 1 (not created in timing)
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:1/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("ayah_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_invalid_ayah_key_format_should_return_404_ayah_not_found(self):
+        """Verify that malformed or out-of-range ayah keys return 404 ayah_not_found."""
+        # Act - Non-canonical ayah keys
+        cases = ["invalid", "2", "2:abc", "115:1", "0:1", "1:0"]
+        for key in cases:
+            response = self.client.get(f"/recitations/{self.asset.id}/ayah/{key}/")
+            self.assertEqual(404, response.status_code, f"Expected 404 for key {key}, got {response.status_code}")
+            self.assertEqual("ayah_not_found", response.json().get("error_name"))
+
+    def test_get_ayah_audio_where_asset_restricted_for_tenant_should_return_404_asset_not_found(self):
+        """Verify that tenant-restricted assets return 404 asset_not_found on public API."""
+        # Arrange
+        self.asset.restricted_for_tenant = True
+        self.asset.save(update_fields=["restricted_for_tenant"])
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual("asset_not_found", response.json().get("error_name"))
+
+    @override_settings(ENFORCE_ASSET_ACCESS_ON_PUBLIC_API=True)
+    def test_get_ayah_audio_where_private_asset_without_api_key_should_return_401(self):
+        """Verify that private assets requested without an API key return 401."""
+        # Arrange
+        self.asset.is_open_access = False
+        self.asset.save(update_fields=["is_open_access"])
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(401, response.status_code, response.content)
+        self.assertEqual("authentication_required", response.json().get("error_name"))
+
+    @override_settings(ENFORCE_ASSET_ACCESS_ON_PUBLIC_API=True)
+    def test_get_ayah_audio_where_private_asset_with_key_but_no_grant_should_return_403(self):
+        """Verify that private assets requested without an approved grant return 403."""
+        # Arrange
+        self.asset.is_open_access = False
+        self.asset.save(update_fields=["is_open_access"])
+        self._authenticate_with_api_key(self.user)
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(403, response.status_code, response.content)
+        self.assertEqual("access_denied", response.json().get("error_name"))
+
+    @override_settings(ENFORCE_ASSET_ACCESS_ON_PUBLIC_API=True)
+    def test_get_ayah_audio_where_private_asset_with_approved_grant_should_return_200(self):
+        """Verify that private assets with an approved developer grant return 200 with private cache headers."""
+        # Arrange
+        self.asset.is_open_access = False
+        self.asset.save(update_fields=["is_open_access"])
+        self._authenticate_with_api_key(self.user)
+        self._grant_access(self.user, self.asset)
+
+        # Act
+        response = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+
+        # Assert
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertEqual("private, no-cache", response.headers.get("Cache-Control"))
+        data = response.json()
+        self.assertEqual("2:255", data["ayah_key"])
+
+    def test_get_ayah_audio_where_cached_should_serve_from_cache_on_second_request(self):
+        """Verify that identical subsequent requests are served from Redis response cache."""
+        # Act - 1st request
+        first_resp = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+        self.assertEqual(200, first_resp.status_code, first_resp.content)
+
+        # Verify cached bytes exist
+        cache_key = recitation_ayah_response_cache_key(self.asset.id, DEFAULT_FOLDER_CACHE_TOKEN, "2:255")
+        cached_raw = cache.get(cache_key)
+        self.assertIsNotNone(cached_raw)
+        cached_json = json.loads(cached_raw)
+        self.assertEqual("2:255", cached_json["ayah_key"])
+
+        # Act - 2nd request (cache hit)
+        second_resp = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+        self.assertEqual(200, second_resp.status_code, second_resp.content)
+        self.assertEqual(first_resp.json(), second_resp.json())

--- a/apps/content/tests/public/test_recitation_ayah.py
+++ b/apps/content/tests/public/test_recitation_ayah.py
@@ -294,3 +294,19 @@ class RecitationAyahAudioPublicApiTest(BaseTestCase):
         second_resp = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
         self.assertEqual(200, second_resp.status_code, second_resp.content)
         self.assertEqual(first_resp.json(), second_resp.json())
+
+    @override_settings(ENFORCE_ASSET_ACCESS_ON_PUBLIC_API=True)
+    def test_get_ayah_audio_where_asset_becomes_private_should_invalidate_cache_and_require_auth(self):
+        """Verify that modifying an asset's visibility invalidates cache and requires auth on subsequent requests."""
+        # Act 1: Initial public request warms the cache
+        resp1 = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+        self.assertEqual(200, resp1.status_code, resp1.content)
+
+        # Act 2: Admin modifies asset to private
+        self.asset.is_open_access = False
+        self.asset.save()
+
+        # Act 3: Subsequent unauthenticated request must be rejected (401), not served from stale cache
+        resp2 = self.client.get(f"/recitations/{self.asset.id}/ayah/2:255/")
+        self.assertEqual(401, resp2.status_code, resp2.content)
+        self.assertEqual("authentication_required", resp2.json().get("error_name"))

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -419,6 +419,18 @@ msgid "Cannot delete Recitation because they are referenced through other object
 msgstr "لا يمكن حذف التلاوة لأن هناك بيانات أخرى مرتبطة بها"
 
 #, python-brace-format
+msgid "Ayah {ayah_key} not found."
+msgstr "لم يتم العثور على الآية {ayah_key}."
+
+#, python-brace-format
+msgid "Asset with id {id} not found."
+msgstr "لم يتم العثور على المورد ذو المعرف {id}."
+
+#, python-brace-format
+msgid "Default folder for asset {id} not found."
+msgstr "لم يتم العثور على المجلد الافتراضي للمورد {id}."
+
+#, python-brace-format
 msgid "Folder with slug {slug} not found."
 msgstr "لم يتم العثور على مجلد بالمعرف {slug}."
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint for retrieving audio and metadata for an individual Quranic ayah.
  * Supports folder variants, access controls, audio timing, file details, and cache-aware responses.
  * Provides appropriate caching behavior for open-access and restricted audio assets.

* **Bug Fixes**
  * Added validation and clear handling for unavailable assets, folders, ayahs, and invalid ayah keys.
  * Updated cached recitation data when asset metadata or visibility changes.

* **Localization**
  * Added Arabic translations for ayah, asset, and folder lookup errors.

* **Tests**
  * Added coverage for retrieval, access permissions, caching, folder variants, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->