### PR TITLE
fix(core): stop permission_class from polluting the DRF metaclass repr

### DIFF
--- a/apps/core/permission_utils.py
+++ b/apps/core/permission_utils.py
@@ -10,10 +10,13 @@ def permission_class(permission_code_name) -> type[permissions.BasePermission]:
 
     CustomPermission.permission_code_name = permission_code_name
 
-    def rep(cls):
-        return f"Permission({permission_code_name})"
-
-    CustomPermission.__class__.__repr__ = rep
+    # Give the generated class a readable name. NOTE: do NOT implement this by
+    # assigning __repr__ on CustomPermission.__class__ — that is the shared
+    # BasePermission metaclass, so it would override the repr of every DRF
+    # permission class in the process (see issue #456). Renaming the class
+    # itself keeps the default type repr, which renders __name__.
+    CustomPermission.__name__ = f"Permission({permission_code_name})"
+    CustomPermission.__qualname__ = CustomPermission.__name__
 
     return CustomPermission
 

--- a/apps/core/tests/test_permission_utils.py
+++ b/apps/core/tests/test_permission_utils.py
@@ -1,0 +1,28 @@
+from django.test import SimpleTestCase
+from rest_framework.permissions import AllowAny, IsAuthenticated
+
+from apps.core.permission_utils import permission_class
+
+
+class PermissionClassReprTest(SimpleTestCase):
+    def test_permission_class_whereCalled_shouldNotAlterBuiltinPermissionReprs(self):
+        # Arrange
+        builtin_reprs = {"IsAuthenticated": repr(IsAuthenticated), "AllowAny": repr(AllowAny)}
+
+        # Act
+        permission_class("perm.one")
+        permission_class("perm.two")
+
+        # Assert: no global side effect on DRF's shared permission classes (see issue #456)
+        self.assertEqual(builtin_reprs["IsAuthenticated"], repr(IsAuthenticated))
+        self.assertEqual(builtin_reprs["AllowAny"], repr(AllowAny))
+
+    def test_permission_class_whereCalled_shouldNameGeneratedClassAfterPermissionCode(self):
+        # Act
+        first = permission_class("perm.one")
+        second = permission_class("perm.two")
+
+        # Assert: each generated class is readable and distinguishable on its own
+        self.assertIn("perm.one", repr(first))
+        self.assertIn("perm.two", repr(second))
+        self.assertNotEqual(repr(first), repr(second))


### PR DESCRIPTION
## Summary

`permission_class()` assigned `__repr__` on `CustomPermission.__class__`, which is DRF's shared
`BasePermission` metaclass — so after 100+ import-time calls, every permission class in the
process (including DRF's own `IsAuthenticated`/`AllowAny`) reported the last-registered code.
This PR names the generated class instead (`__name__`/`__qualname__`), keeping the default type
repr, and adds a regression test.

Fixes #456

## Changes

- `apps/core/permission_utils.py`: set `CustomPermission.__name__`/`__qualname__` to
  `Permission(<code>)` instead of patching the metaclass `__repr__`, with a comment explaining
  why. Generated classes now report e.g. `<class '....Permission(portal.read_mushaf)'>`.
- `apps/core/tests/test_permission_utils.py`: new `SimpleTestCase` (no DB) asserting DRF
  built-ins keep their reprs across calls and each generated class is named after its own code.

## Verification

- Reproduced the bug against the real module before the fix (`IsAuthenticated` ->
  `Permission(perm.two)` after two calls) and confirmed clean reprs plus intact
  `has_permission` grant/deny behavior after the fix, in a minimal local env (installed DRF,
  stubbed `apps.users.models` — no Django settings/DB needed for this import path).
- `ruff check`, `black --check`, `isort --check-only` pass on both files.
- The new test follows the repo's AAA style and `test_<function>_where<criteria>_should<expected>`
  naming. I could not run the full `pytest` suite locally (it requires Postgres + Redis per
  `test_lint.yml`, unavailable on this machine) — relying on CI for the suite run. The test is
  a DB-free `SimpleTestCase`, so it runs anywhere the suite runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the readability of dynamically generated permission class names.
  * Prevented custom permission handling from changing how built-in permission classes are represented.

* **Tests**
  * Added coverage confirming built-in permission representations remain unchanged.
  * Added coverage ensuring generated permissions are distinguishable by permission code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->