### PR TITLE
feat(audit-db): Provision separate audit database + DATABASE_ROUTERS #429

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -291,6 +291,7 @@ jobs:
             # migrations backward-compatible with the still-running old web container.
             echo "🗄️ Running database migrations (one-off)..."
             $COMPOSE run --rm --no-deps web python manage.py migrate --noinput
+            $COMPOSE run --rm --no-deps web python manage.py migrate --database=audit --noinput
 
             # Ensure staticfiles and media volumes are owned by appuser (UID 1001) for existing root-owned volumes
             echo "🔒 Ensuring volume permissions for appuser..."

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,6 +135,12 @@ jobs:
                 echo "DB_HOST=${{ secrets.STAGING_DB_HOST }}";
                 echo "DB_PORT=25060";
                 echo "PGSSLMODE=require";
+                echo "AUDIT_DB_ENGINE=django.db.backends.postgresql";
+                echo "AUDIT_DB_NAME=${{ secrets.STAGING_AUDIT_DB_NAME }}";
+                echo "AUDIT_DB_USER=${{ secrets.STAGING_AUDIT_DB_USER }}";
+                echo "AUDIT_DB_PASSWORD=${{ secrets.STAGING_AUDIT_DB_PASSWORD }}";
+                echo "AUDIT_DB_HOST=${{ secrets.STAGING_AUDIT_DB_HOST }}";
+                echo "AUDIT_DB_PORT=${{ secrets.STAGING_AUDIT_DB_PORT }}";
                 echo "ALLOWED_HOSTS=staging.api.cms.itqan.dev";
                 echo "CORS_ALLOWED_ORIGINS=https://staging.cms.itqan.dev,http://localhost:3000";
                 echo "CLOUDFLARE_R2_BUCKET=${{ secrets.STAGING_CLOUDFLARE_R2_BUCKET }}";
@@ -197,6 +203,12 @@ jobs:
                 echo "DB_HOST=${{ secrets.PROD_DB_HOST }}";
                 echo "DB_PORT=25061";
                 echo "PGSSLMODE=require";
+                echo "AUDIT_DB_ENGINE=django.db.backends.postgresql";
+                echo "AUDIT_DB_NAME=${{ secrets.PROD_AUDIT_DB_NAME }}";
+                echo "AUDIT_DB_USER=${{ secrets.PROD_AUDIT_DB_USER }}";
+                echo "AUDIT_DB_PASSWORD=${{ secrets.PROD_AUDIT_DB_PASSWORD }}";
+                echo "AUDIT_DB_HOST=${{ secrets.PROD_AUDIT_DB_HOST }}";
+                echo "AUDIT_DB_PORT=${{ secrets.PROD_AUDIT_DB_PORT }}";
                 echo "ALLOWED_HOSTS=api.cms.itqan.dev";
                 echo "CORS_ALLOWED_ORIGINS=https://cms.itqan.dev";
                 echo "CLOUDFLARE_R2_BUCKET=${{ secrets.PROD_CLOUDFLARE_R2_BUCKET }}";

--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -101,7 +101,7 @@ jobs:
           cache-to: type=gha,scope=django-dev,mode=max,compression=zstd
 
       - name: Start services
-        run: docker compose -f docker-compose.local.yml up -d --no-build postgres redis
+        run: docker compose -f docker-compose.local.yml up -d --no-build postgres audit-postgres redis
 
       - name: Check DB Migrations
         run: docker compose -f docker-compose.local.yml run --rm django uv run python manage.py makemigrations --check
@@ -109,6 +109,8 @@ jobs:
         run: docker compose -f docker-compose.local.yml run --rm django uv run manage.py extendedmakemessages --no-location --no-wrap --locale=ar --no-fuzzy-matching --keep-header --check
       - name: Run DB Migrations
         run: docker compose -f docker-compose.local.yml run --rm django uv run python manage.py migrate
+      - name: Run Audit DB Migrations
+        run: docker compose -f docker-compose.local.yml run --rm django uv run python manage.py migrate --database=audit
 
       # .mo files are gitignored, so the checkout has none. Tests that assert on
       # translated output need the catalog compiled first, same as the deploy does.

--- a/apps/core/db_routers.py
+++ b/apps/core/db_routers.py
@@ -4,7 +4,13 @@ AUDIT_APP_LABEL = "simple_history"
 class AuditRouter:
     """
     Routes django-simple-history models to the "audit" database,
-    while all other models are routed to the "default" database.
+    other models are routed to the "default" database.
+
+    NOTE: Every `HistoricalRecords()` call MUST be instantiated with
+    `app="simple_history"` (matching AUDIT_APP_LABEL above).
+
+    TODO: Configure HistoricalRecords so `history_user`is stored as a plain user id
+    (no FK/constraint) instead
     """
 
     def db_for_read(self, model, **hints):

--- a/apps/core/db_routers.py
+++ b/apps/core/db_routers.py
@@ -1,0 +1,28 @@
+AUDIT_APP_LABEL = "simple_history"
+
+
+class AuditRouter:
+    """
+    Routes django-simple-history models to the "audit" database,
+    while all other models are routed to the "default" database.
+    """
+
+    def db_for_read(self, model, **hints):
+        if model._meta.app_label == AUDIT_APP_LABEL:
+            return "audit"
+        return None
+
+    def db_for_write(self, model, **hints):
+        if model._meta.app_label == AUDIT_APP_LABEL:
+            return "audit"
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if obj1._meta.app_label == AUDIT_APP_LABEL and obj2._meta.app_label == AUDIT_APP_LABEL:
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if app_label == AUDIT_APP_LABEL:
+            return db == "audit"
+        return db == "default"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -121,7 +121,6 @@ DATABASES = {
             "connect_timeout": 60,
         },
     },
-
     # Note: "audit" is backed up independently from "default".
     # Retention is handled in #434.
     "audit": {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -120,8 +120,21 @@ DATABASES = {
         "OPTIONS": {
             "connect_timeout": 60,
         },
-    }
+    },
+    "audit": {
+        "ENGINE": config("AUDIT_DB_ENGINE", default="django.db.backends.postgresql"),
+        "NAME": config("AUDIT_DB_NAME", default="itqan_audit"),
+        "USER": config("AUDIT_DB_USER", default="postgres"),
+        "PASSWORD": config("AUDIT_DB_PASSWORD", default="postgres"),
+        "HOST": config("AUDIT_DB_HOST", default="localhost"),
+        "PORT": config("AUDIT_DB_PORT", default="5432"),
+        "OPTIONS": {
+            "connect_timeout": 60,
+        },
+    },
 }
+
+DATABASE_ROUTERS = ["apps.core.db_routers.AuditRouter"]
 
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -121,6 +121,9 @@ DATABASES = {
             "connect_timeout": 60,
         },
     },
+
+    # Note: "audit" is backed up independently from "default".
+    # Retention is handled in #434.
     "audit": {
         "ENGINE": config("AUDIT_DB_ENGINE", default="django.db.backends.postgresql"),
         "NAME": config("AUDIT_DB_NAME", default="itqan_audit"),

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -64,6 +64,18 @@ settings.DATABASES["default"].update(
     }
 )
 
+settings.DATABASES["audit"].update(
+    {
+        "ENGINE": "django.db.backends.postgresql",
+        "CONN_MAX_AGE": 0,
+        "DISABLE_SERVER_SIDE_CURSORS": True,
+        "OPTIONS": {
+            "sslmode": "require",
+            "connect_timeout": 10,
+        },
+    }
+)
+
 # ============================================================
 # Cache
 # ============================================================

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -52,7 +52,19 @@ settings.DATABASES.update(
                 # gunicorn's full --timeout 600.
                 "options": "-c statement_timeout=30000",
             },
-        }
+        },
+        "audit": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": config("AUDIT_DB_NAME"),
+            "USER": config("AUDIT_DB_USER"),
+            "PASSWORD": config("AUDIT_DB_PASSWORD"),
+            "HOST": config("AUDIT_DB_HOST"),
+            "PORT": config("AUDIT_DB_PORT"),
+            "OPTIONS": {
+                "sslmode": "require",
+                "connect_timeout": 10,
+            },
+        },
     }
 )
 

--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -23,6 +23,15 @@ fi
 #
 # For standalone/manual runs of this image, set RUN_PREP=1 to run them here.
 if [ "${RUN_PREP:-0}" = "1" ]; then
+    if [ -n "${AUDIT_DB_HOST}" ]; then
+        echo "Waiting for audit database at ${AUDIT_DB_HOST}:${AUDIT_DB_PORT:-5432}..."
+        until nc -z "${AUDIT_DB_HOST}" "${AUDIT_DB_PORT:-5432}"; do
+            echo "Audit database not ready, waiting..."
+            sleep 1
+        done
+        echo "Audit database is ready!"
+    fi
+
     echo "Running database migrations..."
     python manage.py migrate --noinput
     python manage.py migrate --database=audit --noinput

--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -25,6 +25,7 @@ fi
 if [ "${RUN_PREP:-0}" = "1" ]; then
     echo "Running database migrations..."
     python manage.py migrate --noinput
+    python manage.py migrate --database=audit --noinput
 
     echo "Collecting static files..."
     python manage.py collectstatic --noinput

--- a/deployment/docker/env.template
+++ b/deployment/docker/env.template
@@ -13,6 +13,14 @@ DB_HOST=your_db_host
 DB_PORT=25060
 PGSSLMODE=require
 
+# Audit Database Configuration (separate managed PostgreSQL instance)
+AUDIT_DB_ENGINE=django.db.backends.postgresql
+AUDIT_DB_NAME=your_audit_db_name
+AUDIT_DB_USER=your_audit_db_user
+AUDIT_DB_PASSWORD=your_audit_db_password
+AUDIT_DB_HOST=your_audit_db_host
+AUDIT_DB_PORT=25060
+
 # CORS Configuration
 CORS_ALLOWED_ORIGINS=https://your-frontend-domain.com,https://staging.your-frontend-domain.com
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
     volumes:
       - postgres_data:/var/lib/postgresql/data
-  
+
   audit-postgres:
     image: postgres:15-alpine
     environment:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,6 +9,12 @@ x-common-env: &common-env
   DB_PASSWORD: postgres
   DB_HOST: postgres
   DB_PORT: 5432
+  AUDIT_DB_ENGINE: django.db.backends.postgresql
+  AUDIT_DB_NAME: itqan_audit
+  AUDIT_DB_USER: postgres
+  AUDIT_DB_PASSWORD: postgres
+  AUDIT_DB_HOST: audit-postgres
+  AUDIT_DB_PORT: 5432
   REDIS_URL: redis://redis:6379/1
   CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672//
   CELERY_RESULT_BACKEND: redis://redis:6379/0
@@ -31,6 +37,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      audit-postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
       rabbitmq:
@@ -52,6 +60,20 @@ services:
       retries: 5
     volumes:
       - postgres_data:/var/lib/postgresql/data
+  
+  audit-postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: itqan_audit
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - audit_postgres_data:/var/lib/postgresql/data
 
   redis:
     image: redis:7-alpine
@@ -93,6 +115,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      audit-postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
       rabbitmq:
@@ -114,6 +138,8 @@ services:
       - /app/.venv
     depends_on:
       postgres:
+        condition: service_healthy
+      audit-postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
@@ -140,4 +166,5 @@ services:
 
 volumes:
   postgres_data:
+  audit_postgres_data:
   rabbitmq_data:


### PR DESCRIPTION
Provisions the separate `audit` Postgres database and `DATABASE_ROUTERS` from #429.

Closes #429

## What this does

- New `audit` database in settings (local, staging, production)
- `AuditRouter` routes `simple_history` models to `audit`, everything else stays on `default`
- `audit-postgres` service added to `docker-compose.local.yml`
- CI and deploy now run `migrate --database=audit` alongside the normal migrate

## Acceptance criteria

- [x] Second Postgres database provisioned
- [x] `DATABASE_ROUTERS` added
- [x] Cross-DB `history_user` handling documented for #431
- [x] `migrate --database=audit` wired into CI/deploy
- [x] Backup/ops note added

## Testing

Ran both databases locally with `docker-compose.local.yml`, migrated `default` and `audit` separately, and confirmed via `psql` that only `audit` gets historical tables (currently none, since `simple_history` isn't installed yet in #430).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit data is now stored in a separate PostgreSQL database.
  * Audit database migrations run automatically during local setup, testing, staging, and production deployments.
  * Local development includes a dedicated, health-checked audit database with persistent storage.

* **Infrastructure**
  * Staging and production support dedicated audit database configuration with secure connections.
  * Audit database connection settings can be configured through environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->