### PR TITLE
fix(content): defer version notification dispatch

### DIFF
--- a/apps/content/services/asset.py
+++ b/apps/content/services/asset.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.db import transaction
+
 from apps.content.models import AssetVersion
 from apps.content.tasks import notify_asset_version_created
 
@@ -23,5 +25,5 @@ class AssetService:
         """
         Notify users who have access to this asset.
         """
-        notify_asset_version_created.delay(asset_version.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(asset_version.pk))
         logger.info(f"Asset update email queued [asset_version_id={asset_version.pk}]")

--- a/apps/content/services/asset_content.py
+++ b/apps/content/services/asset_content.py
@@ -273,7 +273,7 @@ class AssetContentService:
             draft.summary = summary
         published = self.repo.publish_draft(draft)
         logger.info(f"Draft published [version_id={published.pk}, asset_id={asset.pk}]")
-        notify_asset_version_created.delay(published.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(published.pk))
         return published
 
     def discard_draft(

--- a/apps/content/services/font.py
+++ b/apps/content/services/font.py
@@ -241,7 +241,7 @@ class FontService:
             file=file,
         )
         logger.info(f"Font version created [version_id={version.pk}, asset_id={asset.pk}, slug={font_slug}]")
-        notify_asset_version_created.delay(version.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(version.pk))
         return version
 
     def update_font_version(

--- a/apps/content/services/mushaf.py
+++ b/apps/content/services/mushaf.py
@@ -243,7 +243,7 @@ class MushafService:
             file=file,
         )
         logger.info(f"Mushaf version created [version_id={version.pk}, asset_id={asset.pk}, slug={mushaf_slug}]")
-        notify_asset_version_created.delay(version.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(version.pk))
         return version
 
     def update_mushaf_version(

--- a/apps/content/services/tafsir.py
+++ b/apps/content/services/tafsir.py
@@ -246,7 +246,7 @@ class TafsirService:
         if file:
             import_uploaded_file_into_entries(version)
         logger.info(f"Tafsir version created [version_id={version.pk}, asset_id={asset.pk}, slug={tafsir_slug}]")
-        notify_asset_version_created.delay(version.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(version.pk))
         return version
 
     def update_tafsir_version(

--- a/apps/content/services/translation.py
+++ b/apps/content/services/translation.py
@@ -250,7 +250,7 @@ class TranslationService:
         logger.info(
             f"Translation version created [version_id={version.pk}, asset_id={asset.pk}, slug={translation_slug}]"
         )
-        notify_asset_version_created.delay(version.pk)
+        transaction.on_commit(lambda: notify_asset_version_created.delay(version.pk))
         return version
 
     def update_translation_version(

--- a/apps/content/tests/portal/fonts/test_fonts_versions.py
+++ b/apps/content/tests/portal/fonts/test_fonts_versions.py
@@ -160,10 +160,11 @@ class FontVersionCreateTest(FontVersionBaseTest):
         file = SimpleUploadedFile("font.pdf", b"content", content_type="application/pdf")
 
         # Act
-        response = self.client.post(
-            f"/portal/fonts/{self.font.slug}/versions/",
-            data={"asset_id": self.font.id, "name": "2.0.0", "summary": "New release", "file": file},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/portal/fonts/{self.font.slug}/versions/",
+                data={"asset_id": self.font.id, "name": "2.0.0", "summary": "New release", "file": file},
+            )
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)

--- a/apps/content/tests/portal/mushafs/test_mushafs_versions.py
+++ b/apps/content/tests/portal/mushafs/test_mushafs_versions.py
@@ -160,10 +160,11 @@ class MushafVersionCreateTest(MushafVersionBaseTest):
         file = SimpleUploadedFile("mushaf.pdf", b"content", content_type="application/pdf")
 
         # Act
-        response = self.client.post(
-            f"/portal/mushafs/{self.mushaf.slug}/versions/",
-            data={"asset_id": self.mushaf.id, "name": "2.0.0", "summary": "New release", "file": file},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/portal/mushafs/{self.mushaf.slug}/versions/",
+                data={"asset_id": self.mushaf.id, "name": "2.0.0", "summary": "New release", "file": file},
+            )
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)

--- a/apps/content/tests/portal/tafsirs/test_tafsirs_versions.py
+++ b/apps/content/tests/portal/tafsirs/test_tafsirs_versions.py
@@ -160,10 +160,11 @@ class TafsirVersionCreateTest(TafsirVersionBaseTest):
         file = SimpleUploadedFile("tafsir.pdf", b"content", content_type="application/pdf")
 
         # Act
-        response = self.client.post(
-            f"/portal/tafsirs/{self.tafsir.slug}/versions/",
-            data={"asset_id": self.tafsir.id, "name": "2.0.0", "summary": "New release", "file": file},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/portal/tafsirs/{self.tafsir.slug}/versions/",
+                data={"asset_id": self.tafsir.id, "name": "2.0.0", "summary": "New release", "file": file},
+            )
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)

--- a/apps/content/tests/portal/translations/test_translations_versions.py
+++ b/apps/content/tests/portal/translations/test_translations_versions.py
@@ -162,10 +162,11 @@ class TranslationVersionCreateTest(TranslationVersionBaseTest):
         file = SimpleUploadedFile("translation.pdf", b"content", content_type="application/pdf")
 
         # Act
-        response = self.client.post(
-            f"/portal/translations/{self.translation.slug}/versions/",
-            data={"asset_id": self.translation.id, "name": "2.0.0", "summary": "New release", "file": file},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/portal/translations/{self.translation.slug}/versions/",
+                data={"asset_id": self.translation.id, "name": "2.0.0", "summary": "New release", "file": file},
+            )
 
         # Assert
         self.assertEqual(201, response.status_code, response.content)

--- a/apps/content/tests/services/test_asset_access_service.py
+++ b/apps/content/tests/services/test_asset_access_service.py
@@ -260,11 +260,6 @@ _OUTCOME_TASK = "apps.content.tasks.send_access_request_outcome_email"
 
 
 class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.patch_on_commit()
-
     def setUp(self):
         super().setUp()
         self.service = AssetAccessRequestService(AssetAccessRequestRepository())
@@ -290,7 +285,7 @@ class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
         asset = _make_asset(self.publisher, auto_accept=False)
         req = self._make_request(asset)
 
-        with patch(_OUTCOME_TASK) as mock_task:
+        with patch(_OUTCOME_TASK) as mock_task, self.captureOnCommitCallbacks(execute=True):
             self.service.accept(self.member, req.id)
 
         mock_task.delay.assert_called_once_with(req.id)
@@ -299,7 +294,7 @@ class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
         asset = _make_asset(self.publisher, auto_accept=False)
         req = self._make_request(asset)
 
-        with patch(_OUTCOME_TASK) as mock_task:
+        with patch(_OUTCOME_TASK) as mock_task, self.captureOnCommitCallbacks(execute=True):
             self.service.reject(self.member, req.id, "no")
 
         mock_task.delay.assert_called_once_with(req.id)
@@ -317,7 +312,7 @@ class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
     def test_request_access_auto_accept_enqueues_outcome_email(self):
         asset = _make_asset(self.publisher, auto_accept=True)
 
-        with patch(_OUTCOME_TASK) as mock_outcome:
+        with patch(_OUTCOME_TASK) as mock_outcome, self.captureOnCommitCallbacks(execute=True):
             request, _access = self.service.request_access(
                 user=self.developer, asset=asset, purpose="purpose", intended_use="non-commercial"
             )
@@ -328,7 +323,7 @@ class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
         asset = _make_asset(self.publisher, auto_accept=False)
         existing = self._make_request(asset)
 
-        with patch(_OUTCOME_TASK) as mock_outcome:
+        with patch(_OUTCOME_TASK) as mock_outcome, self.captureOnCommitCallbacks(execute=True):
             request, _access = self.service.request_access(
                 user=self.developer, asset=asset, purpose="purpose", intended_use="non-commercial"
             )
@@ -342,7 +337,7 @@ class AssetAccessRequestServiceNotificationsTests(BaseTestCase):
         self.publisher.auto_accept_access_requests = True
         self.publisher.save(update_fields=["auto_accept_access_requests"])
 
-        with patch(_OUTCOME_TASK) as mock_outcome:
+        with patch(_OUTCOME_TASK) as mock_outcome, self.captureOnCommitCallbacks(execute=True):
             request, _access = self.service.request_access(
                 user=self.developer, asset=asset, purpose="purpose", intended_use="non-commercial"
             )

--- a/apps/content/tests/services/test_asset_service.py
+++ b/apps/content/tests/services/test_asset_service.py
@@ -34,7 +34,8 @@ class TestAssetService(BaseTestCase):
         )
 
         # Act
-        service.create_version(asset_version)
+        with self.captureOnCommitCallbacks(execute=True):
+            service.create_version(asset_version)
 
         # Assert
         self.assertIsNotNone(asset_version.pk)

--- a/apps/core/tests/base.py
+++ b/apps/core/tests/base.py
@@ -1,7 +1,6 @@
 import base64
 import secrets
 from typing import Literal
-from unittest.mock import patch
 
 import boto3
 from django.conf import settings
@@ -64,12 +63,6 @@ class BaseTestCase(TestCase):
             CLOUDFLARE_R2_SECRET_ACCESS_KEY="testing",
         )
         cls._storage_override.enable()
-
-    @classmethod
-    def patch_on_commit(cls):
-        patcher = patch("django.db.transaction.on_commit", side_effect=lambda f: f())
-        patcher.start()
-        cls.addClassCleanup(patcher.stop)
 
     def authenticate_user(
         self,


### PR DESCRIPTION
## Description
Fixes a race condition where version notification emails were silently dropped when assets and asset versions were created or published.
## Root Cause
In version creation flows (e.g. `create_font_with_optional_version`, `create_tafsir_version`, and admin formsets), `notify_asset_version_created.delay(...)` was dispatched directly inside active `transaction.atomic()` blocks.
In production and staging (`CELERY_TASK_ALWAYS_EAGER = False`), a Celery worker frequently consumed the message before the outer web process finished committing the transaction to PostgreSQL. Under PostgreSQL's `READ COMMITTED` isolation level, `AssetVersion.objects.get(pk=...)` failed with `DoesNotExist`. In `AssetVersionNotifier.notify_new_version`, this exception was caught, logged as a warning, and silently returned — completing the Celery task successfully without retry and permanently dropping subscriber notification emails.
## Solution
1. **Atomic On-Commit Dispatches**: Wrapped all `notify_asset_version_created.delay(...)` dispatches in `transaction.on_commit(lambda: ...)` across all version services so tasks are only delivered to the message broker after PostgreSQL confirms the transaction commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset version notifications are now sent only after the related database changes are successfully saved.
  * Prevents notifications from being triggered for versions whose creation or publishing transaction fails.
  * Applies consistently to asset, font, mushaf, tafsir, and translation versions.
  * Ensures notifications are also correctly handled when publishing drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->